### PR TITLE
Initialize model classes upon filtering, not on class load

### DIFF
--- a/lib/mutations/model_filter.rb
+++ b/lib/mutations/model_filter.rb
@@ -11,6 +11,11 @@ module Mutations
       super(opts)
       @name = name
 
+    end
+
+    def filter(data)
+
+      # Initialize the model class and builder
       class_const = options[:class] || @name.to_s.camelize
       class_const = class_const.constantize if class_const.is_a?(String)
       self.options[:class] = class_const
@@ -18,9 +23,6 @@ module Mutations
       if options[:builder]
         options[:builder] = options[:builder].constantize if options[:builder].is_a?(String)
       end
-    end
-
-    def filter(data)
 
       # Handle nil case
       if data.nil?

--- a/spec/model_filter_spec.rb
+++ b/spec/model_filter_spec.rb
@@ -27,21 +27,24 @@ describe "Mutations::ModelFilter" do
   # it "disallows different types of models" do
   # end
 
-  it "raises an exception during initialization if constantization fails" do
+  it "raises an exception during filtering if constantization fails" do
+    f = Mutations::ModelFilter.new(:complex_model)
     assert_raises NameError do
-      Mutations::ModelFilter.new(:complex_model)
+      f.filter(nil)
     end
   end
 
-  it "raises an exception during initialization if constantization of class fails" do
+  it "raises an exception during filtering if constantization of class fails" do
+    f = Mutations::ModelFilter.new(:simple_model, class: "ComplexModel")
     assert_raises NameError do
-      Mutations::ModelFilter.new(:simple_model, class: "ComplexModel")
+      f.filter(nil)
     end
   end
 
-  it "raises an exception during initialization if constantization of builder fails" do
+  it "raises an exception during filtering if constantization of builder fails" do
+    f = Mutations::ModelFilter.new(:simple_model, builder: "ComplexModel")
     assert_raises NameError do
-      Mutations::ModelFilter.new(:simple_model, builder: "ComplexModel")
+      f.filter(nil)
     end
   end
 


### PR DESCRIPTION
We are using the mutations gem in a project and experienced issues with mocking out model classes. Because the `ModelFilter` is initialized upon class load, it is not possible to first mock a model. In our unit tests, we completely mock out our ActiveRecord model:

``` ruby
class MyMutation
   required do
       model :my_model
   end
end

class MyModel < ActiveRecord::Base
end

describe MyMutation do

    before do
      mock_model("MyModel")
    end

    it "..." do
       # Some tests
    end

end
```

This code would raise a `constant ActiveRecord not found` exception because mutations tries to constantize `my_model` when loading the `MyMutation` class. I think it is better to look for the model class when the actual filtering is happing, this allows for easier mocking of these classes.
