### PR TITLE
Add the :default option for the StringFilter

### DIFF
--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -9,15 +9,21 @@ module Mutations
       max_length: nil,      # Can be a number like 10, meaning that at most 10 codepoints are permitted
       matches: nil,         # Can be a regexp
       in: nil,              # Can be an array like %w(red blue green)
-      discard_empty: false  # If the param is optional, discard_empty: true drops empty fields.
+      discard_empty: false, # If the param is optional, discard_empty: true drops empty fields.
+      #default: "some default string"
     }
 
     def filter(data)
 
       # Handle nil case
       if data.nil?
-        return [nil, nil] if options[:nils]
-        return [nil, :nils]
+        if has_default?
+          return [default, nil]
+        elsif options[:nils]
+          return [nil, nil]
+        else
+          return [nil, :nils]
+        end
       end
 
       # At this point, data is not nil. If it's not a string, convert it to a string for some standard classes

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -135,4 +135,11 @@ describe "Mutations::StringFilter" do
     assert_equal "red", filtered
     assert_equal nil, errors
   end
+
+  it "uses the default value when nil" do
+    sf = Mutations::StringFilter.new(default: "red")
+    filtered, errors = sf.filter(nil)
+    assert_equal "red", filtered
+    assert_equal nil, errors
+  end
 end


### PR DESCRIPTION
Can't add @default_options[:default] = nil because then has_default?
will return true and the HashFilter will break.

Example:

``` ruby
class StringExample < Mutations::Command
  required do
    string :name, default: "John Doe"
  end
end

StringExample.new.inputs
# => {"name"=>"John Doe"}
```
