### PR TITLE
In projects with ActiveSupport the invalid dates are not handled correctly

### DIFF
--- a/lib/mutations/date_filter.rb
+++ b/lib/mutations/date_filter.rb
@@ -16,8 +16,6 @@ module Mutations
 
       if data.is_a?(Date) # Date and DateTime
         actual_date = data
-      elsif data.respond_to?(:to_date)  # Time
-        actual_date = data.to_date
       elsif data.is_a?(String)
         begin
           actual_date = if options[:format]
@@ -28,6 +26,8 @@ module Mutations
         rescue ArgumentError
           return [nil, :date]
         end
+      elsif data.respond_to?(:to_date)  # Time
+        actual_date = data.to_date
       else
         return [nil, :date]
       end


### PR DESCRIPTION
ActiveSupport adds the to_date function to a string
http://guides.rubyonrails.org/active_support_core_extensions.html#string-conversions

When an invalid date is entered it would throw an ArgumentError because the string isn't handled in the rescue block.

Just altering the order fixed this issue, strings are now matched before objects that respond to the to_date function.
