### PR TITLE
Added empty option for floats and integers.

### DIFF
--- a/lib/mutations/float_filter.rb
+++ b/lib/mutations/float_filter.rb
@@ -2,6 +2,7 @@ module Mutations
   class FloatFilter < InputFilter
     @default_options = {
       :nils => false,       # true allows an explicit nil to be valid. Overrides any other options
+      :empty => false,      # true allows the value to be empty
       :min => nil,          # lowest value, inclusive
       :max => nil           # highest value, inclusive
     }
@@ -12,6 +13,15 @@ module Mutations
       if data.nil?
         return [nil, nil] if options[:nils]
         return [nil, :nils]
+      end
+
+      # Check if the data is empty
+      if data == ""
+        if options[:empty]
+          return [data, nil]
+        else
+          return [data, :empty]
+        end
       end
 
       # Ensure it's the correct data type (Float)

--- a/lib/mutations/integer_filter.rb
+++ b/lib/mutations/integer_filter.rb
@@ -2,6 +2,7 @@ module Mutations
   class IntegerFilter < InputFilter
     @default_options = {
       :nils => false,       # true allows an explicit nil to be valid. Overrides any other options
+      :empty => false,      # true allows the value to be empty
       :min => nil,          # lowest value, inclusive
       :max => nil,          # highest value, inclusive
       :in => nil            # Can be an array like %w(3 4 5)
@@ -13,6 +14,15 @@ module Mutations
       if data.nil?
         return [nil, nil] if options[:nils]
         return [nil, :nils]
+      end
+
+      # Check if the data is empty
+      if data == ""
+        if options[:empty]
+          return [data, nil]
+        else
+          return [data, :empty]
+        end
       end
 
       # Ensure it's the correct data type (Fixnum)

--- a/spec/float_filter_spec.rb
+++ b/spec/float_filter_spec.rb
@@ -66,6 +66,20 @@ describe "Mutations::FloatFilter" do
     assert_equal nil, errors
   end
 
+  it "considers empty floats to be invalid" do
+    f = Mutations::FloatFilter.new(:empty => false)
+    filtered, errors = f.filter("")
+    assert_equal "", filtered
+    assert_equal :empty, errors
+  end
+
+  it "considers empty floats to be valid" do
+    f = Mutations::FloatFilter.new(:empty => true)
+    filtered, errors = f.filter("")
+    assert_equal "", filtered
+    assert_equal nil, errors
+  end
+
   it "considers low numbers invalid" do
     f = Mutations::FloatFilter.new(:min => 10)
     filtered, errors = f.filter(3)

--- a/spec/integer_filter_spec.rb
+++ b/spec/integer_filter_spec.rb
@@ -45,6 +45,20 @@ describe "Mutations::IntegerFilter" do
     assert_equal nil, errors
   end
 
+  it "considers empty integers to be invalid" do
+    f = Mutations::IntegerFilter.new(:empty => false)
+    filtered, errors = f.filter("")
+    assert_equal "", filtered
+    assert_equal :empty, errors
+  end
+
+  it "considers empty integers to be valid" do
+    f = Mutations::IntegerFilter.new(:empty => true)
+    filtered, errors = f.filter("")
+    assert_equal "", filtered
+    assert_equal nil, errors
+  end
+
   it "considers low numbers invalid" do
     f = Mutations::IntegerFilter.new(:min => 10)
     filtered, errors = f.filter(3)


### PR DESCRIPTION
Integer and floats now have the empty option. This is especially useful when dealing with user input.
