### PR TITLE
Additional filter names are now underscored instead of downcased.

### DIFF
--- a/lib/mutations/additional_filter.rb
+++ b/lib/mutations/additional_filter.rb
@@ -4,7 +4,7 @@ require 'mutations/array_filter'
 module Mutations
   class AdditionalFilter < InputFilter
     def self.inherited(subclass)
-      type_name = subclass.name[/^Mutations::([a-zA-Z]*)Filter$/, 1].downcase
+      type_name = subclass.name[/^Mutations::([a-zA-Z]*)Filter$/, 1].underscore
 
       Mutations::HashFilter.register_additional_filter(subclass, type_name)
       Mutations::ArrayFilter.register_additional_filter(subclass, type_name)

--- a/spec/additional_filter_spec.rb
+++ b/spec/additional_filter_spec.rb
@@ -13,20 +13,31 @@ describe "Mutations::AdditionalFilter" do
           return [data, nil]
         end
       end
+
+      class MultiWordTestFilter < Mutations::AdditionalFilter
+        @default_options = {
+          :nils => false
+        }
+
+        def filter(data)
+          return [data, nil]
+        end
+      end
     end
 
     class TestCommandUsingAdditionalFilters < Mutations::Command
       required do
         sometest :first_name
+        multi_word_test :last_name
       end
 
       def execute
-        { :first_name => first_name }
+        { :first_name => first_name, :last_name => last_name }
       end
     end
 
     it "should recognize additional filters" do
-      outcome = TestCommandUsingAdditionalFilters.run(:first_name => "John")
+      outcome = TestCommandUsingAdditionalFilters.run(:first_name => "John", :last_name => "Doe")
       assert outcome.success?
       assert_equal nil, outcome.errors
     end


### PR DESCRIPTION
AdditionalFilters had downcased type-names.

``` ruby
class MultiWordTestFilter < Mutations::AdditionalFilter
```

**would create the data type:**

```
multiwordtest
```

**Now it creates the data type:**

```
multi_word_test
```
