### PR TITLE
Removing unneeded requirement for the active_support module.

### DIFF
--- a/lib/mutations.rb
+++ b/lib/mutations.rb
@@ -1,4 +1,3 @@
-require 'active_support'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/string/inflections'
 require 'date'
@@ -30,11 +29,11 @@ module Mutations
     def error_message_creator=(creator)
       @error_message_creator = creator
     end
-    
+
     def cache_constants=(val)
       @cache_constants = val
     end
-    
+
     def cache_constants?
       @cache_constants
     end


### PR DESCRIPTION
The `active_support` module [adds a lot of functionality](https://github.com/rails/rails/blob/master/activesupport/lib/active_support.rb#L30) that `Mutations` isn't using.

We're still using `Inflections` and `HashWithIndifferentAccess`, however, but these are targeted dependencies that are required for the basic function of the `Mutations` library.

Also, some line-ending whitespace was cleaned up.
