### PR TITLE
Proper errors lookup

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -68,7 +68,11 @@ module Mutations
     end
 
     def has_errors?
-      !@errors.nil?
+      !correct?
+    end
+
+    def correct?
+      @errors.nil? || @errors.empty?
     end
 
     def run
@@ -90,7 +94,7 @@ module Mutations
     end
 
     def validation_outcome(result = nil)
-      Outcome.new(!has_errors?, has_errors? ? nil : result, @errors, @inputs)
+      Outcome.new(correct?, has_errors? ? nil : result, @errors, @inputs)
     end
 
   protected


### PR DESCRIPTION
Instead of just checking for nil, now it checks for empty errors hash to say if there are errors.
I've got into this issue while using the `merge_errors` method, which adds an empty error hash before merging, which eventually will break the `has_errors?` method.
