### PR TITLE
Add HashFilter :any option

### DIFF
--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -11,6 +11,7 @@ module Mutations
 
     @default_options = {
       :nils => false,            # true allows an explicit nil to be valid. Overrides any other options
+      :any => false              # any allows any hash contents, including nested hashes
     }
 
     attr_accessor :optional_inputs
@@ -84,6 +85,11 @@ module Mutations
       # We always want a hash with indiffernet access
       unless data.is_a?(HashWithIndifferentAccess)
         data = data.with_indifferent_access
+      end
+
+      # Return unfiltered data when :any option is true
+      if options[:any]
+        return [data, nil]
       end
 
       errors = ErrorHash.new

--- a/spec/hash_filter_spec.rb
+++ b/spec/hash_filter_spec.rb
@@ -93,6 +93,39 @@ describe "Mutations::HashFilter" do
     assert_equal ({"baz" => :integer}), errors.symbolic
   end
 
+  describe ":any option" do
+
+    it "defaults to false" do
+      assert_equal false, Mutations::HashFilter.new.options[:any]
+    end
+
+    it "filters hash when false" do
+      hf = Mutations::HashFilter.new(:any => false) do
+        string :foo
+      end
+      filtered, errors = hf.filter(:foo => "bar", :invalid => "poopin")
+      assert_equal ({"foo" => "bar"}), filtered
+      assert_equal nil, errors
+    end
+
+    it "allows any value when true" do
+      hf = Mutations::HashFilter.new(:any => true)
+      filtered, errors = hf.filter(
+        :foo => "bar",
+        :nested => {
+          :bar => "foo"
+        }
+      )
+      assert_equal ({
+        "foo" => "bar",
+        "nested" => {
+          "bar" => "foo"
+        }
+      }), filtered
+      assert_equal nil, errors
+    end
+  end
+
   describe "optional params and nils" do
     it "bar is optional -- it works if not passed" do
       hf = Mutations::HashFilter.new do


### PR DESCRIPTION
This adds an `:any` option to `HashFilter` which defaults to `false`. When `true`, any value is permitted. 

I have a number of models in my application which accept arbitrary JSON data from the user and I'd like to remove the need for serializing this data into a string when calling a mutation command. With this change, my commands look like:

``` ruby
class Update < Mutations::Command
   required do
      array :email_templates do
         hash do
            required do
              integer :id
              string :identifier
              string :subject_template
            end

            optional do
              string :from
              string :text_template
              string :html_template
              hash :data, :any => true
            end
          end
      end
   end
end
```
