### PR TITLE
Allow blocks to be passed as arguments for additional filters

### DIFF
--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -1,11 +1,11 @@
 module Mutations
   class HashFilter < InputFilter
     def self.register_additional_filter(type_class, type_name)
-      define_method(type_name) do | *args |
+      define_method(type_name) do | *args, &block |
         name = args[0]
         options = args[1] || {}
 
-        @current_inputs[name.to_sym] = type_class.new(options)
+        @current_inputs[name.to_sym] = type_class.new(options, &block)
       end
     end
 

--- a/spec/additional_filter_spec.rb
+++ b/spec/additional_filter_spec.rb
@@ -56,7 +56,7 @@ describe "Mutations::AdditionalFilter" do
 
     it "should be useable in hashes" do
       outcome = TestCommandUsingAdditionalFiltersInHashes.run(
-        :a_hash => { :first_name => "John" } 
+        :a_hash => { :first_name => "John" }
       )
 
       assert outcome.success?
@@ -83,5 +83,47 @@ describe "Mutations::AdditionalFilter" do
       assert outcome.success?
       assert_equal nil, outcome.errors
     end
+
+    module Mutations
+      class AdditionalWithBlockFilter < Mutations::AdditionalFilter
+
+        def initialize(opts={}, &block)
+          super(opts)
+
+          if block_given?
+            instance_eval &block
+          end
+        end
+
+        def should_be_called
+          @was_called = true
+        end
+
+        def filter(data)
+          if @was_called
+            [true, nil]
+          else
+            [nil, :not_called]
+          end
+        end
+      end
+    end
+
+    class TestCommandUsingBlockArgument < Mutations::Command
+      required do
+        additional_with_block :foo do
+          should_be_called
+        end
+      end
+
+      def execute
+        true
+      end
+    end
+
+    it "can have a block constructor" do
+      assert_equal true, TestCommandUsingBlockArgument.run!(:foo => 'bar')
+    end
+
   end
 end


### PR DESCRIPTION
Additional filters can now take blocks as parameters. This allows the additional filters to behave much like the array and hash filters.
