### PR TITLE
Make accessing errors via [ ] operators act as expected

### DIFF
--- a/lib/mutations/errors.rb
+++ b/lib/mutations/errors.rb
@@ -91,7 +91,7 @@ module Mutations
   #     state: ErrorAtom(:in)
   #   }
   # }
-  class ErrorHash < Hash
+  class ErrorHash < HashWithIndifferentAccess
 
     # Returns a nested HashWithIndifferentAccess where the values are symbols.  Eg:
     # {

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -89,4 +89,33 @@ describe "Mutations - errors" do
     end
   end
 
+  describe "error accessibility" do
+    class AddsError < Mutations::Command
+      required do
+        string :str1
+        string :str2
+      end
+
+      def execute
+        add_error(:str1, :validation, 'Str1 is always wrong')
+      end
+    end
+
+    describe 'with validation errors' do
+      it 'allows [] access via symbols or strings' do
+        o = AddsError.run()
+        assert_equal o.errors[:str1], o.errors['str1']
+        assert       !o.errors['str1'].nil?
+      end
+    end
+
+    describe 'with manually added errors' do
+      it  'allows [] access via symbols or strings' do
+        o = AddsError.run(:str1 => 'foo', :str2 => 'bar')
+
+        assert_equal o.errors[:str1], o.errors['str1']
+        assert       !o.errors[:str1].nil?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Given this mutation:

``` ruby
class ManualErrors < Mutations::Command
  required do
    string :str1
  end

  def execute
    add_error(:str1, :validation, 'This is always wrong')
  end
end
```

If I forget to pass any input, and the validations fail:

``` ruby
result = ManualErrors.run()

result.errors[:str1]  #=> #<Mutations::ErrorAtom:0x00000000d3adb33f ...>
result.errors['str1'] #=> nil
```

But when the error is manually added, it's reversed:

``` ruby
result = ManualErrors.run(:str1 => 'inputinput')

result.errors[:str1]  #=> nil
result.errors['str1'] #=> #<Mutations::ErrorAtom:0x0000000001234567 ...>
```

This is very confusing. Subclassing `ErrorHash` from `HashWithIndifferentAccess` (instead of just from `Hash` should remove this confusion and make accessing errors more consistent.
