### PR TITLE
allowing :empty on integer filter

### DIFF
--- a/lib/mutations/integer_filter.rb
+++ b/lib/mutations/integer_filter.rb
@@ -2,6 +2,7 @@ module Mutations
   class IntegerFilter < AdditionalFilter
     @default_options = {
       :nils => false,          # true allows an explicit nil to be valid. Overrides any other options
+      :empty => false,         # false disallows "".  true allows "" and overrides any other validations (b/c they couldn't be true if it's empty)
       :min => nil,             # lowest value, inclusive
       :max => nil,             # highest value, inclusive
       :in => nil,              # Can be an array like %w(3 4 5)
@@ -14,9 +15,15 @@ module Mutations
         return [nil, nil] if options[:nils]
         return [nil, :nils]
       end
-      
-      # Now check if it's empty:
-      return [data, :empty] if data == ""
+
+      # Now check if it's blank:
+      if data == ""
+        if options[:empty]
+          return [data, nil]
+        else
+          return [data, :empty]
+        end
+      end
 
       # Ensure it's the correct data type (Fixnum)
       if !data.is_a?(Fixnum)

--- a/spec/integer_filter_spec.rb
+++ b/spec/integer_filter_spec.rb
@@ -44,11 +44,19 @@ describe "Mutations::IntegerFilter" do
     assert_equal nil, filtered
     assert_equal nil, errors
   end
-  
-  it "considers empty strings to be empty" do
-    f = Mutations::IntegerFilter.new
-    filtered, errors = f.filter("")
+
+  it "considers empty strings to be invalid" do
+    sf = Mutations::IntegerFilter.new(:empty => false)
+    filtered, errors = sf.filter("")
+    assert_equal "", filtered
     assert_equal :empty, errors
+  end
+
+  it "considers empty strings to be valid" do
+    sf = Mutations::IntegerFilter.new(:empty => true)
+    filtered, errors = sf.filter("")
+    assert_equal "", filtered
+    assert_equal nil, errors
   end
 
   it "considers low numbers invalid" do


### PR DESCRIPTION
I'm having a problem with specific scenario (which is very likely to rails env). If I want rails to set default value (set on database level) to some field, we need to pass empty string to it, like this: `User.create(name: "")`

While this works for strings, it does't work with integers since mutations will raise an error if empty string is passed to integer. This simple patch will fix that. Don't know whether it could have different implications...
