### PR TITLE
allowing :discard_nils option to be passed to optional inputs

### DIFF
--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -28,7 +28,7 @@ module Mutations
 
     # Only relevant for optional params
     def discard_nils?
-      !options[:nils]
+      options.fetch(:discard_nils, !options[:nils])
     end
 
     def discard_empty?


### PR DESCRIPTION
Sometimes i want optional attributes, but if passed, i want them to be required.

Example:

``` ruby
Users::Update.run! id: 1, name: "Zoga", role: "admin" # would update both name and role
Users::Update.run! id: 1, role: "power_admin" # would update only role
Users::Update.run! id: 1, name: nil # would raise validation error
```

Both `:name` and `:role` are optional inputs. But if name is passed as nil, it shouldn't be discarded (current behavior). 
