### PR TITLE
Allow default values to be callable objects

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -6,7 +6,8 @@ module Mutations
         keys = self.input_filters.send("#{meth}_keys")
         keys.each do |key|
           define_method(key) do
-            @inputs[key]
+            v = @inputs[key]
+            v.respond_to?(:call) ? v.call : v
           end
 
           define_method("#{key}_present?") do

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -264,4 +264,31 @@ describe "Command" do
     end
   end
 
+  describe "OptionalCallableDefaultsCommand" do
+    class OptionalCallableDefaultsCommand < Mutations::Command
+
+      optional do
+        date :created_at, default: -> { Time.now }
+      end
+
+      def execute
+        created_at
+      end
+    end
+
+    it "should return the input default when not defined" do
+      time = Time.now
+      Time.stub :now, time do
+        input = {}
+        assert_equal time, OptionalCallableDefaultsCommand.run!(input)
+      end
+    end
+
+    it "should return the input passed when defined" do
+      created_at = Date.parse("2009-09-03")
+      input = { "created_at" => created_at }
+      assert_equal created_at, OptionalCallableDefaultsCommand.run!(input)
+    end
+  end
+
 end


### PR DESCRIPTION
It would be useful to be able to set callable objects when setting default values in mutations. One simple example:

``` ruby
class UpdateCommand < Mutations::Command
  optional do
    date :updated_at, default: -> { Time.now }
  end

  def execute
    ...
  end
end
```

Otherwise the Time.now would acquire the time the class was read during initialization.
