### PR TITLE
Add license to gemspec

### DIFF
--- a/mutations.gemspec
+++ b/mutations.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.email = 'jnovak@gmail.com'
   s.homepage = 'http://github.com/cypriss/mutations'
   s.summary = s.description = 'Compose your business logic into commands that sanitize and validate input.'
+  s.licenses = %w[MIT]
 
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files test`.split("\n")


### PR DESCRIPTION
This will make the license show up on RubyGems, which is useful for auditing purposes.
