### PR TITLE
Add the ability to describe input filters 

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -51,6 +51,10 @@ module Mutations
         end
       end
 
+      def input_descriptions
+        input_filters.input_descriptions if input_filters.respond_to?(:input_descriptions)
+      end
+
     end
 
     # Instance methods

--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -5,6 +5,10 @@ module Mutations
         name = args[0]
         options = args[1] || {}
 
+        if described = current_input_description
+          @input_descriptions[name.to_sym] = described
+        end
+
         @current_inputs[name.to_sym] = type_class.new(options, &block)
       end
     end
@@ -16,10 +20,13 @@ module Mutations
     attr_accessor :optional_inputs
     attr_accessor :required_inputs
 
+    attr_accessor :input_descriptions, :input_description
+
     def initialize(opts = {}, &block)
       super(opts)
 
       @optional_inputs = {}
+      @input_descriptions = {}
       @required_inputs = {}
       @current_inputs = @required_inputs
 
@@ -37,6 +44,16 @@ module Mutations
         dupped.required_inputs[k] = v
       end
       dupped
+    end
+
+    def desc input_description
+      @input_description = input_description
+    end
+
+    def current_input_description
+      val = @input_description && @input_description.dup
+      @input_description = nil
+      val
     end
 
     def required(&block)


### PR DESCRIPTION
This is a minor enhancement to the filter configuration DSL that allows for developers to provide a brief human readable description of the filter / argument for the command.

``` ruby
class CreateBook < Mutations::Command
  required do
     desc "The Title of the book" 
     string :title
  end
end
```

In large projects which have a lot of commands, the ability to generate API documentation for those commands is very nice and the mutations gem already allows for a great level of introspection and so this is a natural extension of that.

Previously I solved this by adding the 'description' key to the filter options, but I like this approach as inline documentation becomes more of a first class citizen.

With this API in place you can inspect via:  `CreateBook.input_descriptions`
