### PR TITLE
Remove unprintable characters from strings by default

### DIFF
--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -9,7 +9,8 @@ module Mutations
       :max_length => nil,      # Can be a number like 10, meaning that at most 10 codepoints are permitted
       :matches => nil,         # Can be a regexp
       :in => nil,              # Can be an array like %w(red blue green)
-      :discard_empty => false  # If the param is optional, discard_empty: true drops empty fields.
+      :discard_empty => false, # If the param is optional, discard_empty: true drops empty fields.
+      :unprintable => false    # false removes unprintable characters from the string
     }
 
     def filter(data)
@@ -26,7 +27,10 @@ module Mutations
       # Now ensure it's a string:
       return [data, :string] unless data.is_a?(String)
 
-      # At this point, data is a string.  Now transform it using strip:
+      # At this point, data is a string. Now remove unprintable characters from the string:
+      data = data.gsub(/[^[:print:]\t\r\n]+/, ' ') unless options[:unprintable]
+
+      # Transform it using strip:
       data = data.strip if options[:strip]
 
       # Now check if it's blank:

--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -10,7 +10,7 @@ module Mutations
       :matches => nil,         # Can be a regexp
       :in => nil,              # Can be an array like %w(red blue green)
       :discard_empty => false, # If the param is optional, discard_empty: true drops empty fields.
-      :unprintable => false    # false removes unprintable characters from the string
+      :allow_control_characters => false    # false removes unprintable characters from the string
     }
 
     def filter(data)
@@ -28,7 +28,7 @@ module Mutations
       return [data, :string] unless data.is_a?(String)
 
       # At this point, data is a string. Now remove unprintable characters from the string:
-      data = data.gsub(/[^[:print:]\t\r\n]+/, ' ') unless options[:unprintable]
+      data = data.gsub(/[^[:print:]\t\r\n]+/, ' ') unless options[:allow_control_characters]
 
       # Transform it using strip:
       data = data.strip if options[:strip]

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -215,21 +215,21 @@ describe "Mutations::StringFilter" do
   end
 
   it "removes unprintable characters" do
-    sf = Mutations::StringFilter.new(:unprintable => false)
+    sf = Mutations::StringFilter.new(:allow_control_characters => false)
     filtered, errors = sf.filter("Hello\u0000\u0000World!")
     assert_equal "Hello World!", filtered
     assert_equal nil, errors
   end
 
   it "doesn't remove unprintable characters" do
-    sf = Mutations::StringFilter.new(:unprintable => true)
+    sf = Mutations::StringFilter.new(:allow_control_characters => true)
     filtered, errors = sf.filter("Hello\u0000\u0000World!")
     assert_equal "Hello\u0000\u0000World!", filtered
     assert_equal nil, errors
   end
 
   it "doesn't remove tabs, spaces and line breaks" do
-    sf = Mutations::StringFilter.new(:unprintable => false)
+    sf = Mutations::StringFilter.new(:allow_control_characters => false)
     filtered, errors = sf.filter("Hello,\tWorld !\r\nNew Line")
     assert_equal "Hello,\tWorld !\r\nNew Line", filtered
     assert_equal nil, errors

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -80,6 +80,13 @@ describe "Mutations::StringFilter" do
     assert_equal :empty, errors
   end
 
+  it "considers strings that contain only unprintable characters to be invalid" do
+    sf = Mutations::StringFilter.new(:empty => false)
+    filtered, errors = sf.filter("\u0000\u0000")
+    assert_equal "", filtered
+    assert_equal :empty, errors
+  end
+
   it "considers long strings to be invalid" do
     sf = Mutations::StringFilter.new(:max_length => 5)
     filtered, errors = sf.filter("123456")
@@ -206,4 +213,26 @@ describe "Mutations::StringFilter" do
     assert_equal true, filtered
     assert_equal :string, errors
   end
+
+  it "removes unprintable characters" do
+    sf = Mutations::StringFilter.new(:unprintable => false)
+    filtered, errors = sf.filter("Hello\u0000\u0000World!")
+    assert_equal "Hello World!", filtered
+    assert_equal nil, errors
+  end
+
+  it "doesn't remove unprintable characters" do
+    sf = Mutations::StringFilter.new(:unprintable => true)
+    filtered, errors = sf.filter("Hello\u0000\u0000World!")
+    assert_equal "Hello\u0000\u0000World!", filtered
+    assert_equal nil, errors
+  end
+
+  it "doesn't remove tabs, spaces and line breaks" do
+    sf = Mutations::StringFilter.new(:unprintable => false)
+    filtered, errors = sf.filter("Hello,\tWorld !\r\nNew Line")
+    assert_equal "Hello,\tWorld !\r\nNew Line", filtered
+    assert_equal nil, errors
+  end
+
 end


### PR DESCRIPTION
User input at times contains unprintable characters (i.e. `"\u0000"`) that can cause problems. If they're located at the beginning or end of a string, `:strip` will take care of them. If they're somewhere in the middle of a string, they won't be removed.

This patch adds an additional option `:unprintable` that defines whether or not unprintable characters are allowed in the string. It is false by default, meaning that all unprintable characters will be removed.