### PR TITLE
Upgrade bundler in travis-ci before test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler # the default bundler version on travis is very old and causes 1.9.3 build issues
 rvm:
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
The 1.9.3 build fails in travis due to an old bundler version
being included in the default environment.

https://github.com/travis-ci/travis-ci/issues/3531 is the travis issue
tracking this. https://github.com/rubygems/rubygems/issues/1419 is the
related rubygems tracking the NoMethodError exception we are currently
seeing in the 1.9.3 build environment.