### PR TITLE
Clean up redundant dependencies in Gemfile & Gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,8 @@
 source 'http://rubygems.org'
 gemspec
 
-gem 'activesupport'
-
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'psych'
   gem 'rubinius-developer_tools'
-end
-
-group :test do
-  gem 'minitest', '~> 4.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
-require 'rake/testtask'
+require "bundler/gem_tasks"
+require "rake/testtask"
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'spec'
+  test.libs << "spec"
   # test.warning = true # Wow that outputs a lot of shit
-  test.pattern = 'spec/**/*_spec.rb'
+  test.pattern = "spec/**/*_spec.rb"
 end
 
 task :default => :test

--- a/mutations.gemspec
+++ b/mutations.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files test`.split("\n")
   s.require_path = 'lib'
 
-  s.add_dependency 'activesupport'
+  s.add_dependency "activesupport", "~> 3"
   s.add_development_dependency 'minitest', '~> 4'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Use the `gemspec` directive in the Gemfile to point to runtime and development dependencies there instead of duplicating them in both.

Add `bundler/gem_tasks` to Rakefile to provide gem-specific tasks.