### PR TITLE
Fix warnings and add Ruby 2.4 to test matrix

### DIFF
--- a/lib/mutations/boolean_filter.rb
+++ b/lib/mutations/boolean_filter.rb
@@ -20,8 +20,8 @@ module Mutations
       # If data is true or false, we win.
       return [data, nil] if data == true || data == false
 
-      # If data is a Fixnum, like 1, let's convert it to a string first
-      data = data.to_s if data.is_a?(Fixnum)
+      # If data is an Integer, like 1, let's convert it to a string first
+      data = data.to_s if data.is_a?(Integer)
 
       # If data's a string, try to convert it to a boolean. If we can't, it's invalid.
       if data.is_a?(String)

--- a/lib/mutations/file_filter.rb
+++ b/lib/mutations/file_filter.rb
@@ -24,7 +24,7 @@ module Mutations
         return [data, :file] unless data.respond_to?(method)
       end
 
-      if options[:size].is_a?(Fixnum)
+      if options[:size].is_a?(Integer)
         return [data, :size] if data.size > options[:size]
       end
 

--- a/lib/mutations/float_filter.rb
+++ b/lib/mutations/float_filter.rb
@@ -21,7 +21,7 @@ module Mutations
       if !data.is_a?(Float)
         if data.is_a?(String) && data =~ /^[-+]?\d*\.?\d+/
           data = data.to_f
-        elsif data.is_a?(Fixnum)
+        elsif data.is_a?(Integer)
           data = data.to_f
         else
           return [data, :float]

--- a/lib/mutations/integer_filter.rb
+++ b/lib/mutations/integer_filter.rb
@@ -23,8 +23,8 @@ module Mutations
       # Now check if it's empty:
       return [data, :empty] if data == ""
 
-      # Ensure it's the correct data type (Fixnum)
-      if !data.is_a?(Fixnum)
+      # Ensure it's the correct data type (Integer)
+      if !data.is_a?(Integer)
         if data.is_a?(String) && data =~ /^-?\d/
           data = data.to_i
         else

--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -22,7 +22,7 @@ module Mutations
       end
 
       # At this point, data is not nil. If it's not a string, convert it to a string for some standard classes
-      data = data.to_s if !options[:strict] && [TrueClass, FalseClass, Fixnum, Float, BigDecimal, Symbol].include?(data.class)
+      data = data.to_s if !options[:strict] && [TrueClass, FalseClass, Integer, Float, BigDecimal, Symbol].any? { |klass| data.is_a?(klass) }
 
       # Now ensure it's a string:
       return [data, :string] unless data.is_a?(String)

--- a/spec/array_filter_spec.rb
+++ b/spec/array_filter_spec.rb
@@ -33,21 +33,21 @@ describe "Mutations::ArrayFilter" do
   end
 
   it "lets you specify a class, and has valid elements" do
-    f = Mutations::ArrayFilter.new(:arr, :class => Fixnum)
+    f = Mutations::ArrayFilter.new(:arr, :class => Integer)
     filtered, errors = f.filter([1,2,3])
     assert_equal nil, errors
     assert_equal [1,2,3], filtered
   end
 
   it "lets you specify a class as a string, and has valid elements" do
-    f = Mutations::ArrayFilter.new(:arr, :class => 'Fixnum')
+    f = Mutations::ArrayFilter.new(:arr, :class => 'Integer')
     filtered, errors = f.filter([1,2,3])
     assert_equal nil, errors
     assert_equal [1,2,3], filtered
   end
 
   it "lets you specify a class, and has invalid elements" do
-    f = Mutations::ArrayFilter.new(:arr, :class => Fixnum)
+    f = Mutations::ArrayFilter.new(:arr, :class => Integer)
     filtered, errors = f.filter([1, "bob"])
     assert_equal [nil, :class], errors.symbolic
     assert_equal [1,"bob"], filtered


### PR DESCRIPTION
The `Fixnum` class has been removed in Ruby 2.4, and the `Integer` class should be used instead: https://bugs.ruby-lang.org/issues/12005

The format of `BigDecimal#inspect` has also changed slightly:  https://github.com/ruby/bigdecimal/commit/ed7bf1e913d378d57507a5d069a28c4a12d9ffa9