### PR TITLE
Provide support for BigDecimal use with float_filter

### DIFF
--- a/lib/mutations/float_filter.rb
+++ b/lib/mutations/float_filter.rb
@@ -13,7 +13,7 @@ module Mutations
         return [nil, nil] if options[:nils]
         return [nil, :nils]
       end
-      
+
       # Now check if it's empty:
       return [data, :empty] if data == ""
 
@@ -21,7 +21,7 @@ module Mutations
       if !data.is_a?(Float)
         if data.is_a?(String) && data =~ /^[-+]?\d*\.?\d+/
           data = data.to_f
-        elsif data.is_a?(Fixnum)
+        elsif data.is_a?(Numeric)
           data = data.to_f
         else
           return [data, :float]

--- a/spec/float_filter_spec.rb
+++ b/spec/float_filter_spec.rb
@@ -65,7 +65,7 @@ describe "Mutations::FloatFilter" do
     assert_equal nil, filtered
     assert_equal nil, errors
   end
-  
+
   it "considers empty strings to be empty" do
     f = Mutations::FloatFilter.new
     filtered, errors = f.filter("")
@@ -97,6 +97,14 @@ describe "Mutations::FloatFilter" do
     f = Mutations::FloatFilter.new(:max => 10)
     filtered, errors = f.filter(3)
     assert_equal 3, filtered
+    assert_equal nil, errors
+  end
+
+  it 'allows BigDecimal as input' do
+    f = Mutations::FloatFilter.new
+    value = BigDecimal.new(5)
+    filtered, errors = f.filter(value)
+    assert_equal 5, filtered
     assert_equal nil, errors
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'minitest/unit'
 require 'minitest/autorun'
+require 'bigdecimal'
 require 'pp'
 
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__))


### PR DESCRIPTION
I ran into issues in my tests where I used model.attributes to provide my inputs (e.g. for updates) where I am storing values as BigDecimal instead of Float.

Using `Numeric` instead of `Fixnum` should still work well with `.to_f` but will include support for BigDecimal as input.

All tests pass so I don't think I have gone against some intended behaviour. Let me know if you have any questions?