### PR TITLE
Avoid warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ before_install:
   - gem install bundler # the default bundler version on travis is very old and causes 1.9.3 build issues
 rvm:
   - 1.9.3
-  - jruby-19mode
-  - rbx
+  - jruby-1.7.26
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.7.0

--- a/lib/mutations/array_filter.rb
+++ b/lib/mutations/array_filter.rb
@@ -20,7 +20,7 @@ module Mutations
       @element_filter = nil
 
       if block_given?
-        instance_eval &block
+        instance_eval(&block)
       end
 
       raise ArgumentError.new("Can't supply both a class and a filter") if @element_filter && self.options[:class]

--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -24,7 +24,7 @@ module Mutations
       @current_inputs = @required_inputs
 
       if block_given?
-        instance_eval &block
+        instance_eval(&block)
       end
     end
 
@@ -41,12 +41,12 @@ module Mutations
 
     def required(&block)
       @current_inputs = @required_inputs
-      instance_eval &block
+      instance_eval(&block)
     end
 
     def optional(&block)
       @current_inputs = @optional_inputs
-      instance_eval &block
+      instance_eval(&block)
     end
 
     def required_keys

--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -1,9 +1,7 @@
 module Mutations
   class InputFilter
-    @default_options = {}
-
     def self.default_options
-      @default_options
+      @default_options ||= {}
     end
 
     attr_accessor :options

--- a/spec/additional_filter_spec.rb
+++ b/spec/additional_filter_spec.rb
@@ -91,7 +91,7 @@ describe "Mutations::AdditionalFilter" do
           super(opts)
 
           if block_given?
-            instance_eval &block
+            instance_eval(&block)
           end
         end
 

--- a/spec/array_filter_spec.rb
+++ b/spec/array_filter_spec.rb
@@ -13,7 +13,7 @@ describe "Mutations::ArrayFilter" do
   it "considers non-arrays to be invalid" do
     f = Mutations::ArrayFilter.new(:arr)
     ['hi', true, 1, {:a => "1"}, Object.new].each do |thing|
-      filtered, errors = f.filter(thing)
+      _filtered, errors = f.filter(thing)
       assert_equal :array, errors
     end
   end
@@ -27,8 +27,8 @@ describe "Mutations::ArrayFilter" do
 
   it "considers nil to be valid" do
     f = Mutations::ArrayFilter.new(:arr, :nils => true)
-    filtered, errors = f.filter(nil)
-    filtered, errors = f.filter(nil)
+    _filtered, errors = f.filter(nil)
+    _filtered, errors = f.filter(nil)
     assert_equal nil, errors
   end
 
@@ -56,7 +56,7 @@ describe "Mutations::ArrayFilter" do
   it "lets you use a block to supply an element filter" do
     f = Mutations::ArrayFilter.new(:arr) { string }
 
-    filtered, errors = f.filter(["hi", {:stuff => "ok"}])
+    _filtered, errors = f.filter(["hi", {:stuff => "ok"}])
     assert_nil errors[0]
     assert_equal :string, errors[1].symbolic
   end
@@ -175,7 +175,7 @@ describe "Mutations::ArrayFilter" do
       end
     end
 
-    filtered, errors = f.filter([["h", "e", {}], ["l"], [], [""]])
+    _filtered, errors = f.filter([["h", "e", {}], ["l"], [], [""]])
     assert_equal [[nil, nil, :string], nil, nil, [:empty]], errors.symbolic
     assert_equal [[nil, nil, "Array[2] isn't a string"], nil, nil, ["Array[0] can't be blank"]], errors.message
     assert_equal ["Array[2] isn't a string", "Array[0] can't be blank"], errors.message_list

--- a/spec/boolean_filter_spec.rb
+++ b/spec/boolean_filter_spec.rb
@@ -16,7 +16,7 @@ describe "Mutations::BooleanFilter" do
   it "considers non-booleans to be invalid" do
     f = Mutations::BooleanFilter.new
     [[true], {:a => "1"}, Object.new].each do |thing|
-      filtered, errors = f.filter(thing)
+      _filtered, errors = f.filter(thing)
       assert_equal :boolean, errors
     end
   end
@@ -46,7 +46,7 @@ describe "Mutations::BooleanFilter" do
   
   it "considers empty strings to be empty" do
     f = Mutations::BooleanFilter.new
-    filtered, errors = f.filter("")
+    _filtered, errors = f.filter("")
     assert_equal :empty, errors
   end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -34,7 +34,7 @@ describe "Command" do
 
     it "should throw an exception with run!" do
       assert_raises Mutations::ValidationException do
-        result = SimpleCommand.run!(:name => "John", :email => "john@gmail.com", :amount => "bob")
+        SimpleCommand.run!(:name => "John", :email => "john@gmail.com", :amount => "bob")
       end
     end
 
@@ -89,15 +89,15 @@ describe "Command" do
 
     it "shouldn't accept non-hashes" do
       assert_raises ArgumentError do
-        outcome = SimpleCommand.run(nil)
+        SimpleCommand.run(nil)
       end
 
       assert_raises ArgumentError do
-        outcome = SimpleCommand.run(1)
+        SimpleCommand.run(1)
       end
 
       assert_raises ArgumentError do
-        outcome = SimpleCommand.run({:name => "John"}, 1)
+        SimpleCommand.run({:name => "John"}, 1)
       end
     end
 

--- a/spec/file_filter_spec.rb
+++ b/spec/file_filter_spec.rb
@@ -63,7 +63,7 @@ describe "Mutations::FileFilter" do
   
   it "considers empty strings to be empty" do
     f = Mutations::FileFilter.new
-    filtered, errors = f.filter("")
+    _filtered, errors = f.filter("")
     assert_equal :empty, errors
   end
 

--- a/spec/float_filter_spec.rb
+++ b/spec/float_filter_spec.rb
@@ -33,7 +33,7 @@ describe "Mutations::FloatFilter" do
   it "allows negative strings" do
     f = Mutations::FloatFilter.new
     filtered, errors = f.filter("-.14")
-    assert_equal -0.14, filtered
+    assert_equal(-0.14, filtered)
     assert_equal nil, errors
   end
 
@@ -47,7 +47,7 @@ describe "Mutations::FloatFilter" do
   it "doesnt't allow other strings, nor does it allow random objects or symbols" do
     f = Mutations::FloatFilter.new
     ["zero","a1", {}, [], Object.new, :d].each do |thing|
-      filtered, errors = f.filter(thing)
+      _filtered, errors = f.filter(thing)
       assert_equal :float, errors
     end
   end
@@ -68,7 +68,7 @@ describe "Mutations::FloatFilter" do
   
   it "considers empty strings to be empty" do
     f = Mutations::FloatFilter.new
-    filtered, errors = f.filter("")
+    _filtered, errors = f.filter("")
     assert_equal :empty, errors
   end
 

--- a/spec/hash_filter_spec.rb
+++ b/spec/hash_filter_spec.rb
@@ -16,7 +16,7 @@ describe "Mutations::HashFilter" do
     hf = Mutations::HashFilter.new do
       string :foo
     end
-    filtered, errors = hf.filter("bar")
+    _filtered, errors = hf.filter("bar")
     assert_equal :hash, errors
   end
 
@@ -70,7 +70,7 @@ describe "Mutations::HashFilter" do
     hf = Mutations::HashFilter.new do
       string :*
     end
-    filtered, errors = hf.filter(:foo => [])
+    _filtered, errors = hf.filter(:foo => [])
     assert_equal ({"foo" => :string}), errors.symbolic
   end
 
@@ -89,7 +89,7 @@ describe "Mutations::HashFilter" do
       string :foo
       integer :*
     end
-    filtered, errors = hf.filter(:foo => "bar", :baz => "poopin")
+    _filtered, errors = hf.filter(:foo => "bar", :baz => "poopin")
     assert_equal ({"baz" => :integer}), errors.symbolic
   end
 
@@ -196,7 +196,7 @@ describe "Mutations::HashFilter" do
         end
       end
 
-      filtered, errors = hf.filter(:foo => "bar", :bar => "")
+      _filtered, errors = hf.filter(:foo => "bar", :bar => "")
       assert_equal ({"bar" => :empty}), errors.symbolic
     end
 
@@ -255,7 +255,7 @@ describe "Mutations::HashFilter" do
         end
       end
 
-      filtered, errors = hf.filter(:foo => "bar")
+      _filtered, errors = hf.filter(:foo => "bar")
       assert_equal ({"foo" => :integer}), errors.symbolic
     end
   end

--- a/spec/integer_filter_spec.rb
+++ b/spec/integer_filter_spec.rb
@@ -19,14 +19,14 @@ describe "Mutations::IntegerFilter" do
   it "allows negative strings" do
     f = Mutations::IntegerFilter.new
     filtered, errors = f.filter("-3")
-    assert_equal -3, filtered
+    assert_equal(-3, filtered)
     assert_equal nil, errors
   end
 
   it "doesnt't allow other strings, nor does it allow random objects or symbols" do
     f = Mutations::IntegerFilter.new
     ["zero","a1", {}, [], Object.new, :d].each do |thing|
-      filtered, errors = f.filter(thing)
+      _filtered, errors = f.filter(thing)
       assert_equal :integer, errors
     end
   end
@@ -47,13 +47,13 @@ describe "Mutations::IntegerFilter" do
   
   it "considers empty strings to be empty" do
     f = Mutations::IntegerFilter.new
-    filtered, errors = f.filter("")
+    _filtered, errors = f.filter("")
     assert_equal :empty, errors
   end
 
   it "considers empty strings to be nil if empty_is_nil option is used" do
     f = Mutations::IntegerFilter.new(:empty_is_nil => true)
-    filtered, errors = f.filter("")
+    _filtered, errors = f.filter("")
     assert_equal :nils, errors
   end
 

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -26,7 +26,7 @@ describe "Mutations::StringFilter" do
   it "disallows non-string" do
     sf = Mutations::StringFilter.new
     [["foo"], {:a => "1"}, Object.new].each do |thing|
-      filtered, errors = sf.filter(thing)
+      _filtered, errors = sf.filter(thing)
       assert_equal :string, errors
     end
   end
@@ -160,7 +160,7 @@ describe "Mutations::StringFilter" do
   it "converts bigdecimals to strings" do
     sf = Mutations::StringFilter.new(:strict => false)
     filtered, errors = sf.filter(BigDecimal.new("0.0001"))
-    assert_equal "0.1E-3", filtered
+    assert_equal("0.1E-3", filtered.upcase)
     assert_equal nil, errors
   end
 


### PR DESCRIPTION
This PR works around warnings in specs.

For 2.4.0, Ruby returns a different string from BigDecimal. It is uppercased. I changed the expectation.