### PR TITLE
Fix warnings caused by redefining ErrorfulCommand

### DIFF
--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -191,7 +191,7 @@ describe "Command" do
   end
 
   describe "MultiErrorCommand" do
-    class ErrorfulCommand < Mutations::Command
+    class MultiErrorCommand < Mutations::Command
 
       required { string :name }
       optional { string :email }
@@ -208,7 +208,7 @@ describe "Command" do
     end
 
     it "should let you merge errors" do
-      outcome = ErrorfulCommand.run(:name => "John", :email => "john@gmail.com")
+      outcome = MultiErrorCommand.run(:name => "John", :email => "john@gmail.com")
 
       assert !outcome.success?
       assert_nil outcome.result


### PR DESCRIPTION
This fixes the following warnings in the test suite:

    lib/mutations/command.rb:8: warning: method redefined; discarding old name
    lib/mutations/command.rb:8: warning: previous definition of name was here
    lib/mutations/command.rb:12: warning: method redefined; discarding old name_present?
    lib/mutations/command.rb:12: warning: previous definition of name_present? was here
    lib/mutations/command.rb:16: warning: method redefined; discarding old name=
    lib/mutations/command.rb:16: warning: previous definition of name= was here
    lib/mutations/command.rb:8: warning: method redefined; discarding old email
    lib/mutations/command.rb:8: warning: previous definition of email was here
    lib/mutations/command.rb:12: warning: method redefined; discarding old email_present?
    lib/mutations/command.rb:12: warning: previous definition of email_present? was here
    lib/mutations/command.rb:16: warning: method redefined; discarding old email=
    lib/mutations/command.rb:16: warning: previous definition of email= was here
    spec/command_spec.rb:199: warning: method redefined; discarding old execute
    spec/command_spec.rb:155: warning: previous definition of execute was here

The tests now run warning-free.