### PR TITLE
Use assert_equal to check symbolic errors

### DIFF
--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -164,7 +164,7 @@ describe "Command" do
 
       assert !outcome.success?
       assert_nil outcome.result
-      assert :is_a_bob, outcome.errors.symbolic[:bob]
+      assert_equal :is_a_bob, outcome.errors.symbolic[:bob]
     end
   end
 
@@ -186,7 +186,7 @@ describe "Command" do
 
       assert !outcome.success?
       assert_nil outcome.result
-      assert :is_a_bob, outcome.errors[:people].symbolic[:bob]
+      assert_equal :is_a_bob, outcome.errors[:people].symbolic[:bob]
     end
   end
 
@@ -212,8 +212,8 @@ describe "Command" do
 
       assert !outcome.success?
       assert_nil outcome.result
-      assert :is_short, outcome.errors.symbolic[:bob]
-      assert :is_fat, outcome.errors.symbolic[:sally]
+      assert_equal :is_short, outcome.errors.symbolic[:bob]
+      assert_equal :is_fat, outcome.errors.symbolic[:sally]
     end
   end
 


### PR DESCRIPTION
The `assert` method [checks whether its first argument is truthy](http://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert). These assertions could never fail, since symbols are always truthy.

We actually want to check if the first argument and the second argument are equal, [which is what `assert_equal` does](http://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_equal).