### PR TITLE
Document default behavior of nil and discard_empty for string

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,56 @@ outcome.errors.message # => {password_confirmation: "Your passwords don't match"
 
 If you want to tie the validation messages into your I18n system, you'll need to [write a custom error message generator](https://github.com/cypriss/mutations/wiki/Custom-Error-Messages).
 
+### Optional fields
+
+By default optional fields with `nil` values are discarded.
+
+```ruby
+class UserSignup < Mutations::Command
+
+  ...
+
+  optional do
+    ...
+    string :city
+  end
+
+  ...
+end
+```
+
+With this handy behavior, it means, the outcome returns a `success` with no validation errors.
+
+```ruby
+outcome = UserSignup.run(name: "John Doe", email: "john@doe.com", city: nil)
+outcome.success?
+=> true
+```
+
+Next, specifically for string type fields, there is an option to allow empty strings, `""`, for optional fields.
+
+```ruby
+class UserSignup < Mutations::Command
+
+  ...
+
+  optional do
+    ...
+    string :city, discard_empty: true
+  end
+
+  ...
+end
+```
+
+With `discard_empty`, optional fields with empty strings are discarded as well, returning outcome with `success`.
+
+```ruby
+outcome = UserSignup.run(name: "John Doe", email: "john@doe.com", city: "")
+outcome.success?
+=> true
+```
+
 ## FAQs
 
 ### Is this better than the 'Rails Way'?

--- a/TODO
+++ b/TODO
@@ -1,12 +1,9 @@
- - Document default behavior discarding of nils for optional params
- - document string.discard_empty
-
- - protected parameters:
-     optional do
-       boolean :skip_confirmation, protected: true
-     end
-     Given the above, skip_confirmation is only accepted as a parameter if it's passed in a later hash, eg this would make it take:
-     User::ChangeEmail.run!(params, user: current_user, skip_confirmation: true)
-     But this would not:
-     params = {user: current_user, skip_confirmation: true}
-     User::ChangeEmail.run!(params)
+- protected parameters:
+   optional do
+     boolean :skip_confirmation, protected: true
+   end
+   Given the above, skip_confirmation is only accepted as a parameter if it's passed in a later hash, eg this would make it take:
+   User::ChangeEmail.run!(params, user: current_user, skip_confirmation: true)
+   But this would not:
+   params = {user: current_user, skip_confirmation: true}
+   User::ChangeEmail.run!(params)


### PR DESCRIPTION
We recently learnt about the default behavior of `nil` and `discard_empty` for
string in optional fields. Adding the same to README, so its easier to reference.
From the TODO, looks like it was intended to be added as well :).