### PR TITLE
Extend add_error to also support complex error arrays, hashes

### DIFF
--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -59,12 +59,12 @@ describe "Command" do
 
     it "should execute custom validate method during run" do
       outcome = SimpleCommand.run(:name => "JohnLong", :email => "xxxx")
-      
+
       assert !outcome.success?
       assert_nil outcome.result
       assert_equal :invalid, outcome.errors.symbolic[:email]
     end
-    
+
     it "should execute custom validate method only if regular validations succeed" do
       outcome = SimpleCommand.validate(:name => "JohnTooLong", :email => "xxxx")
 
@@ -214,6 +214,67 @@ describe "Command" do
       assert_nil outcome.result
       assert_equal :is_short, outcome.errors.symbolic[:bob]
       assert_equal :is_fat, outcome.errors.symbolic[:sally]
+    end
+  end
+
+  describe "NestedErrorHashCommand" do
+    class NestedErrorHashCommand < Mutations::Command
+      required do
+        array :services do
+          model :object, class: Hash
+        end
+      end
+
+      def validate
+        service_errors = Mutations::ErrorHash.new
+        service_errors[:name] = Mutations::ErrorAtom.new(:name, :exists, message: "Service with name foo already exists")
+
+        add_error("services.foo", service_errors)
+      end
+    end
+
+    it "should let you add sub-mutation errors" do
+      outcome = NestedErrorHashCommand.run('services' => [
+          { 'name' => "foo" },
+      ])
+
+      assert !outcome.success?
+      assert_nil outcome.result
+      assert_equal({'services' => { 'foo' => { 'name' => :exists }}}, outcome.errors.symbolic)
+    end
+  end
+
+  describe "NestedErrorArrayCommand" do
+    class NestedErrorArrayCommand < Mutations::Command
+      required do
+        array :links do
+          hash do
+            required do
+              string :name
+            end
+          end
+        end
+      end
+
+      def validate
+        links_errors = Mutations::ErrorArray.new
+        links_errors << Mutations::ErrorAtom.new(:name, :not_found, message: "Link foo not found")
+        links_errors << Mutations::ErrorAtom.new(:name, :not_found, message: "Link bar not found")
+
+        add_error("links", links_errors)
+      end
+    end
+
+    it "should let you add sub-mutation errors" do
+      outcome = NestedErrorArrayCommand.run('links' => [
+          { 'name' => "foo" },
+          { 'name' => "bar" },
+      ])
+
+      assert !outcome.success?
+      assert_nil outcome.result
+      assert_equal({'links' => [:not_found, :not_found]}, outcome.errors.symbolic)
+      assert_equal({'links' => ["Link foo not found", "Link bar not found"]}, outcome.errors.message)
     end
   end
 


### PR DESCRIPTION
We are using `mutations` in the Kontena Server, and we have two usecases related to validation errors that the current `Mutations::Command` API does not really support:

* Reporting manual validation errors for multi-valued `array` fields, such as when doing a DB lookup for each array item in the `validate` method

    Our current approach for validating such fields looks something like this: [`GridServices::Common#validate_secrets_exist`](https://github.com/kontena/kontena/blob/v1.2.2/server/app/mutations/grid_services/common.rb#L141-L148)

    ```ruby
          optional do
            array :secrets do
            hash do
              required do
                string :secret
                string :name
              end
            end
          end
    ```
    ```ruby
    def validate_secrets_exist(grid, secrets)
      secrets.each do |s|
        unless grid.grid_secrets.find_by(name: s[:secret])
          add_error(:secrets, :not_found, "Secret #{s[:secret]} does not exist")
        end
      end
    end
    ```

    However, if there are multiple non-existant secrets in the `secrets` array, then we can only report one of those validation errors.

    Being able to report all of the resulting validation errors for each of the array items requires something to add a `Mutations::ErrorArray` to `@errors`, which is not supported by the current API.

* Nested mutations, where the `Stacks::Create` mutation takes an array of `service` hashes, and passes each of those to the `Service::Create` mutation

    Our current approach of handling such nested outcome errors involves calling `add_error` for each field in the resulting outcome errors hash: [`Stacks::Common#handle_service_outcome_errors`](https://github.com/kontena/kontena/blob/v1.2.2/server/app/mutations/stacks/common.rb#L19-L23)

    ```ruby
    def handle_service_outcome_errors(service_name, errors)
      errors.each do |key, atom|
         add_error("services.#{service_name}.#{key}", symbolic, message)
      end
    end

    def validate
      self.services.each do |service|
        outcome = GridServices::Create.validate(service)
        unless outcome.success?
          handle_service_outcome_errors(service[:name], outcome.errors)
        end
      end
    end
    ```

    However, while this works okay for simple sub-mutation errors, this fails badly on any validation errors for any `array` fields, because there is no way to add the resulting `Mutations::ErrorArray` error to the top-level mutation `@errors`. Currently this fails with a `ArgumentError (Invalid kind)` when passing the array of symbols returned by `Mutations::ErrorArray#symbolic` to `add_error`.

    The `merge_errors` method doesn't work either, because each of the identically-shaped sub-mutation outcome errors needs to be added as nested errors with some unique `services.foo` key.

This PR extends the `Mutations::Command#add_error` to provide a solution for both of these uses-cases by also accepting structured `Mutations::ErrorAtom`, `Mutations::ErrorArray` and `Mutations::ErrorHash` errors with a structured key. The simple case of a `add_error(key, :kind, "message")` is implicitly converted to a `Mutations::ErrorAtom`.