### PR TITLE
Optional error_key filter for command inputs

### DIFF
--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -113,16 +113,18 @@ module Mutations
             elsif !is_required && sub_error == :nils && filterer.discard_nils?
               data.delete(key)
             else
-              sub_error = ErrorAtom.new(key, sub_error) if sub_error.is_a?(Symbol)
+              error_key = filterer.options[:error_key] || key
+              sub_error = ErrorAtom.new(error_key, sub_error) if sub_error.is_a?(Symbol)
               errors[key] = sub_error
             end
           end
-          
+
           if !data.has_key?(key)
             if filterer.has_default?
               filtered_data[key] = filterer.default
             elsif is_required
-              errors[key] = ErrorAtom.new(key, :required)
+              error_key = filterer.options[:error_key] || key
+              errors[key] = ErrorAtom.new(error_key, :required)
             end
           end
         end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -59,12 +59,12 @@ describe "Command" do
 
     it "should execute custom validate method during run" do
       outcome = SimpleCommand.run(:name => "JohnLong", :email => "xxxx")
-      
+
       assert !outcome.success?
       assert_nil outcome.result
       assert_equal :invalid, outcome.errors.symbolic[:email]
     end
-    
+
     it "should execute custom validate method only if regular validations succeed" do
       outcome = SimpleCommand.validate(:name => "JohnTooLong", :email => "xxxx")
 
@@ -165,6 +165,29 @@ describe "Command" do
       assert !outcome.success?
       assert_nil outcome.result
       assert_equal :is_a_bob, outcome.errors.symbolic[:bob]
+    end
+  end
+
+  describe "CustomErrorKeyCommand" do
+    class CustomErrorKeyCommand < Mutations::Command
+      required { string :name, error_key: :other_name }
+      optional { string :email, min_length: 4, error_key: :other_email }
+    end
+
+    it "should return the optional error key in the error message if required" do
+      outcome = CustomErrorKeyCommand.run
+
+      assert !outcome.success?
+      assert_equal :required, outcome.errors.symbolic[:name]
+      assert_equal "Other Name is required", outcome.errors.message[:name]
+    end
+
+    it "should return the optional error key in the error message if optional" do
+      outcome = CustomErrorKeyCommand.run(email: "foo")
+
+      assert !outcome.success?
+      assert_equal :min_length, outcome.errors.symbolic[:email]
+      assert_equal "Other Email is too short", outcome.errors.message[:email]
     end
   end
 


### PR DESCRIPTION
**Description**: There are cases in which the keys used in a command do not
fully describe the interface by which the command receives its inputs.
This can cause cases where validation errors returned in a command
don't make as much sense. For example, a command which takes an input
of:

```ruby
hash :company do
  required do
    string :name
  end
end
```

would, if blank, return the error "Name cannot be blank", when a more
suitable error message may look something like "Company Name cannot
be blank".

This commit adds an optional filter which
will allows one to display error messages using an optional error key
which, when present, will override the key passed in:

```ruby
hash :company do
  required do
    string :name, error_key: :company_name
  end
end
```

Which will return the error message we desire.