### PR TITLE
Feature: dynamic hash

### DIFF
--- a/lib/mutations/hash_filter.rb
+++ b/lib/mutations/hash_filter.rb
@@ -11,6 +11,7 @@ module Mutations
 
     @default_options = {
       :nils => false,            # true allows an explicit nil to be valid. Overrides any other options
+      :accept_any_key => false
     }
 
     attr_accessor :optional_inputs
@@ -85,6 +86,9 @@ module Mutations
       unless data.is_a?(HashWithIndifferentAccess)
         data = data.with_indifferent_access
       end
+      
+      # Skip later validations if hash should be accepted as is.
+      return [data, nil] if options[:accept_any_key]
 
       errors = ErrorHash.new
       filtered_data = HashWithIndifferentAccess.new

--- a/spec/hash_filter_spec.rb
+++ b/spec/hash_filter_spec.rb
@@ -258,6 +258,13 @@ describe "Mutations::HashFilter" do
       _filtered, errors = hf.filter(:foo => "bar")
       assert_equal ({"foo" => :integer}), errors.symbolic
     end
-  end
 
+    it "should not discard hash if option accept_any_key is provided" do
+      hf = Mutations::HashFilter.new(accept_any_key: true)
+
+      filtered, errors = hf.filter(:foo => "bar", :foobar => { :bar => "foo" })
+      assert_equal nil, errors
+      assert_equal({"foo" => "bar", "foobar" => { "bar" => "foo" }}, filtered)
+    end
+  end
 end


### PR DESCRIPTION
Greetings,

Sometimes we need to accept dynamic hashes, especially when we use JSON fields (e.g postgres JSON fields) in the database. I've implemented an option that would skip inner fields validation/filtering in hash filter.

Can you include it in the project ?