### PR TITLE
add SymbolFilter to additional filters

### DIFF
--- a/lib/mutations.rb
+++ b/lib/mutations.rb
@@ -20,6 +20,7 @@ require 'mutations/file_filter'
 require 'mutations/model_filter'
 require 'mutations/array_filter'
 require 'mutations/hash_filter'
+require 'mutations/symbol_filter'
 require 'mutations/outcome'
 require 'mutations/command'
 

--- a/lib/mutations/symbol_filter.rb
+++ b/lib/mutations/symbol_filter.rb
@@ -1,0 +1,22 @@
+module Mutations
+  class SymbolFilter < AdditionalFilter
+    @default_options = {
+      :nils => false,    # true allows an explicit nil to be valid. Overrides any other options
+    }
+
+    def filter(data)
+      if data.nil?
+        return [nil, nil] if options[:nils]
+        return [nil, :nils]
+      end
+
+      case data
+      when Symbol # we're good!
+      when String then data = data.to_sym
+      else return [nil, :symbol]
+      end
+
+      [data, nil]
+    end
+  end
+end

--- a/spec/symbol_filter_spec.rb
+++ b/spec/symbol_filter_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Mutations::SymbolFilter do
+  let(:options){ {} }
+  let(:outcome){ Mutations::SymbolFilter.new(options).filter(input) }
+  let(:result){ outcome[0] }
+  let(:errors){ outcome[1] }
+
+  describe 'string input' do
+    let(:input){ 'foo' }
+
+    it{ assert_equal(result, :foo) }
+    it{ assert_nil(errors) }
+  end
+
+  describe 'symbol input' do
+    let(:input){ :foo }
+
+    it{ assert_equal(result, :foo) }
+    it{ assert_nil(errors) }
+  end
+
+  describe 'input not a symbol' do
+    let(:input){ 1 }
+
+    it{ assert_nil(result) }
+    it{ assert_equal(errors, :symbol) }
+  end
+
+  describe 'nil input' do
+    let(:input){ nil }
+
+    describe 'nils allowed' do
+      let(:options){ { nils: true } }
+
+      it{ assert_nil(result) }
+      it{ assert_nil(errors) }
+    end
+
+    describe 'nils not allowed' do
+      let(:options){ { nils: false } }
+
+      it{ assert_nil(result) }
+      it{ assert_equal(errors, :nils) }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a filter for symbol inputs to a command.

Usage example:

```ruby
required do
  symbol :api_method
end
```

Tests passing locally:

```shell
Raphs-MacBook-Pro:mutations raph$ git status
On branch raph/symbol-filter
nothing to commit, working directory clean
Raphs-MacBook-Pro:mutations raph$ rake
Run options: --seed 51749

# Running tests:

........................................................................................................................................................................................................................

Finished tests in 0.042228s, 5115.0895 tests/s, 11508.9514 assertions/s.

216 tests, 486 assertions, 0 failures, 0 errors, 0 skips
```