### PR TITLE
ensure symbolic error keys remain symbols

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -106,6 +106,7 @@ module Mutations
     end
 
     # add_error("name", :too_short)
+    # add_error(:name, :too_short)
     # add_error("colors.foreground", :not_a_color) # => to create errors = {colors: {foreground: :not_a_color}}
     # or, supply a custom message:
     # add_error("name", :too_short, "The name 'blahblahblah' is too short!")
@@ -119,7 +120,7 @@ module Mutations
         inner = path.inject(errs) do |cur_errors,part|
           cur_errors[part.to_sym] ||= ErrorHash.new
         end
-        inner[last] = ErrorAtom.new(key, kind, :message => message)
+        inner[last.to_sym] = ErrorAtom.new(key, kind, :message => message)
       end
     end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -153,8 +153,8 @@ describe "Command" do
       optional { string :email }
 
       def execute
-        add_error("bob", :is_a_bob)
-
+        add_error(:bob, :is_a_bob)
+        add_error("jane", :is_a_jane)
         1
       end
     end
@@ -164,7 +164,9 @@ describe "Command" do
 
       assert !outcome.success?
       assert_nil outcome.result
+      assert_equal :is_a_bob, outcome.errors[:bob].symbolic
       assert_equal :is_a_bob, outcome.errors.symbolic[:bob]
+      assert_equal :is_a_jane, outcome.errors.symbolic["jane"]
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -60,6 +60,19 @@ describe "Mutations - errors" do
     assert_equal "Newsletter Subscription isn't a boolean", atom.message
   end
 
+  describe "errors as symbols remain symbols" do
+    class Foo < Mutations::Command
+      def execute
+        add_error(:foo, :bar, "baz")
+      end
+    end
+    let(:outcome){ Foo.run }
+
+    it{ assert_nil(outcome.errors["foo"]) }
+    it{ assert(outcome.errors[:foo]) }
+    it{ assert_equal(outcome.errors[:foo].message, "baz") }
+  end
+
   describe "Bunch o errors" do
     before do
       @outcome = GivesErrors.run(:str1 => "", :str2 => "opt9", :int1 => "zero", :hash1 => {:bool1 => "bob"}, :arr1 => ["bob", 1, "sally"])


### PR DESCRIPTION
Previously, when doing this

`add_error(:foo, :bar, "baz")`

one could not fetch the error by that symbol, only by string.

`outcome.errors["foo"]`

This PR makes a tiny change to preserve the symbol keys.