### PR TITLE
Add empty option for DateFilter

### DIFF
--- a/lib/mutations/date_filter.rb
+++ b/lib/mutations/date_filter.rb
@@ -1,21 +1,26 @@
 module Mutations
   class DateFilter < AdditionalFilter
     @default_options = {
-      :nils => false,       # true allows an explicit nil to be valid. Overrides any other options
-      :format => nil,       # If nil, Date.parse will be used for coercion. If something like "%Y-%m-%d", Date.strptime is used
-      :after => nil,        # A date object, representing the minimum date allowed, inclusive
-      :before => nil        # A date object, representing the maximum date allowed, inclusive
+      :nils => false,         # true allows an explicit nil to be valid. Overrides any other options
+      :empty_is_nil => false, # If true, treat empty string as if it were nil
+      :format => nil,         # If nil, Date.parse will be used for coercion. If something like "%Y-%m-%d", Date.strptime is used
+      :after => nil,          # A date object, representing the minimum date allowed, inclusive
+      :before => nil          # A date object, representing the maximum date allowed, inclusive
     }
 
     def filter(data)
+      if options[:empty_is_nil] && data == ""
+        data = nil
+      end
+
       # Handle nil case
       if data.nil?
         return [nil, nil] if options[:nils]
         return [nil, :nils]
       end
-      
+
       # Now check if it's empty:
-      return [data, :empty] if "" == data 
+      return [data, :empty] if "" == data
 
       if data.is_a?(Date) # Date and DateTime
         actual_date = data
@@ -34,7 +39,7 @@ module Mutations
       else
         return [nil, :date]
       end
-      
+
       # Ok, its a valid date, check if it falls within the range
       if options[:after]
         if actual_date <= options[:after]

--- a/spec/date_filter_spec.rb
+++ b/spec/date_filter_spec.rb
@@ -124,7 +124,7 @@ describe "Mutations::DateFilter" do
     assert_equal nil, filtered
     assert_equal :nils, errors
   end
-  
+
   it "considers empty strings to be empty" do
     f = Mutations::DateFilter.new
     filtered, errors = f.filter("")
@@ -136,6 +136,19 @@ describe "Mutations::DateFilter" do
     f = Mutations::DateFilter.new(:nils => true)
     filtered, errors = f.filter(nil)
 
+    assert_equal nil, filtered
+    assert_equal nil, errors
+  end
+
+  it "considers empty strings to be nil if empty_is_nil option is used" do
+    f = Mutations::DateFilter.new(:empty_is_nil => true)
+    _filtered, errors = f.filter("")
+    assert_equal :nils, errors
+  end
+
+  it "returns empty strings as nil if empty_is_nil option is used" do
+    f = Mutations::DateFilter.new(:empty_is_nil => true, :nils => true)
+    filtered, errors = f.filter("")
     assert_equal nil, filtered
     assert_equal nil, errors
   end


### PR DESCRIPTION
This PR adds an empty option for date filters.

Usage example:
```rb
required do
  date :deleted_on, empty: true
end
```

Tests passing locally:
```
Run options: --seed 38338

# Running tests:

...............................................................................................................................................................................................................

Finished tests in 0.012859s, 16097.6748 tests/s, 37172.4084 assertions/s.

207 tests, 478 assertions, 0 failures, 0 errors, 0 skips
```