### PR TITLE
Respect Mutations.cache_constants in array filters

### DIFF
--- a/lib/mutations/array_filter.rb
+++ b/lib/mutations/array_filter.rb
@@ -40,7 +40,23 @@ module Mutations
       @element_filter = ArrayFilter.new(nil, options, &block)
     end
 
+    def initialize_constants!
+      @initialize_constants ||= begin
+        if options[:class]
+          options[:class] = options[:class].constantize if options[:class].is_a?(String)
+        end
+
+        true
+      end
+
+      unless Mutations.cache_constants?
+        options[:class] = options[:class].to_s.constantize if options[:class]
+      end
+    end
+
     def filter(data)
+      initialize_constants!
+
       # Handle nil case
       if data.nil?
         return [nil, nil] if options[:nils]
@@ -86,10 +102,7 @@ module Mutations
         data, el_errors = @element_filter.filter(data)
         return [data, el_errors] if el_errors
       elsif options[:class]
-        class_const = options[:class]
-        class_const = class_const.constantize if class_const.is_a?(String)
-
-        if !data.is_a?(class_const)
+        if !data.is_a?(options[:class])
           return [data, :class]
         end
       end

--- a/spec/model_filter_spec.rb
+++ b/spec/model_filter_spec.rb
@@ -60,6 +60,27 @@ describe "Mutations::ModelFilter" do
     assert_equal nil, filtered
     assert_equal nil, errors
   end
+
+  it "will not re-constantize if cache_constants is true" do
+    was = Mutations.cache_constants?
+    Mutations.cache_constants = true
+    f = Mutations::ModelFilter.new(:simple_model)
+    m = SimpleModel.new
+    filtered, errors = f.filter(m)
+    assert_equal m, filtered
+    assert_equal nil, errors
+
+    Object.send(:remove_const, 'SimpleModel')
+
+    class SimpleModel; end
+
+    m = SimpleModel.new
+    filtered, errors = f.filter(m)
+    assert_equal m, filtered
+    assert_equal :model, errors
+
+    Mutations.cache_constants = was
+  end
   
   it "will re-constantize if cache_constants is false" do
     was = Mutations.cache_constants?


### PR DESCRIPTION
Model and array filters both have a `:class` option, which configures them to validate that their input is an instance of the provided class.

By default, model filters resolve the constant once and reuse it for subsequent runs. However if `Mutations.cache_constants` is set to false, the filter will resolve the constant before each run, which allows it to correctly handle constants that are redefined at runtime (by Rails' constant reloading mechanism, for example).

Array filters didn't respect the `Mutations.cache_constants` setting, and always resolved the constant again every time the filter was called; this brings their behaviour in line with model filters.

This is effectively https://github.com/cypriss/mutations/commit/1e2515c8127f93934f64973ab907f6f9d743236a and https://github.com/cypriss/mutations/commit/b5ea6a80a5b29d493dc4485130ab56c0ed386e5a applied to the array filter.