### PR TITLE
Allow arguments that respond to to_hash, instead of only Hash instances

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -56,7 +56,7 @@ module Mutations
     # Instance methods
     def initialize(*args)
       @raw_inputs = args.inject({}.with_indifferent_access) do |h, arg|
-        raise ArgumentError.new("All arguments must be hashes") unless arg.is_a?(Hash)
+        raise ArgumentError.new("All arguments must be hashes") unless arg.respond_to?(:to_hash)
         h.merge!(arg)
       end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -87,7 +87,7 @@ describe "Command" do
       assert_equal ({:name => "John", :email => "bob@jones.com", :amount => 5}).stringify_keys, outcome.result
     end
 
-    it "shouldn't accept non-hashes" do
+    it "shouldn't accept objects that are not hashes or directly mappable to hashes" do
       assert_raises ArgumentError do
         SimpleCommand.run(nil)
       end
@@ -99,6 +99,19 @@ describe "Command" do
       assert_raises ArgumentError do
         SimpleCommand.run({:name => "John"}, 1)
       end
+    end
+
+    it 'should accept objects that are conceptually hashes' do
+      class CustomPersonHash
+        def to_hash
+          { name: 'John', email: 'john@example.com' }
+        end
+      end
+
+      outcome = SimpleCommand.run(CustomPersonHash.new)
+
+      assert outcome.success?
+      assert_equal ({ name: "John", email: "john@example.com" }).stringify_keys, outcome.result
     end
 
     it "should accept nothing at all" do


### PR DESCRIPTION
In rails 5, params are no longer hashes but instances of the type `ActionController::Parameters `. Instead of forcing the inputs of a mutation to be a hash, I changed it so the inputs objects of a mutation need to respond to the `to_h` method instead. 