### PR TITLE
Adding new option for ArrayFilter min_length. fixes #127

### DIFF
--- a/lib/mutations/array_filter.rb
+++ b/lib/mutations/array_filter.rb
@@ -10,7 +10,8 @@ module Mutations
     @default_options = {
       :nils => false,            # true allows an explicit nil to be valid. Overrides any other options
       :class => nil,             # A constant or string indicates that each element of the array needs to be one of these classes
-      :arrayize => false         # true will convert "hi" to ["hi"]. "" converts to []
+      :arrayize => false,        # true will convert "hi" to ["hi"]. "" converts to []
+      :min_length => nil         # Can be a number like 5, meaning 5 objects are required
     }
 
     def initialize(name, opts = {}, &block)
@@ -54,6 +55,8 @@ module Mutations
         errors = ErrorArray.new
         filtered_data = []
         found_error = false
+
+        return [data, :min_length] if options[:min_length] && data.length < options[:min_length]
         data.each_with_index do |el, i|
           el_filtered, el_error = filter_element(el)
           el_error = ErrorAtom.new(@name, el_error, :index => i) if el_error.is_a?(Symbol)

--- a/lib/mutations/array_filter.rb
+++ b/lib/mutations/array_filter.rb
@@ -11,7 +11,8 @@ module Mutations
       :nils => false,            # true allows an explicit nil to be valid. Overrides any other options
       :class => nil,             # A constant or string indicates that each element of the array needs to be one of these classes
       :arrayize => false,        # true will convert "hi" to ["hi"]. "" converts to []
-      :min_length => nil         # Can be a number like 5, meaning 5 objects are required
+      :min_length => nil,        # Can be a number like 5, meaning 5 objects are required
+      :max_length => nil         # Can be a number like 20, meaning no more than 20 objects
     }
 
     def initialize(name, opts = {}, &block)
@@ -57,6 +58,7 @@ module Mutations
         found_error = false
 
         return [data, :min_length] if options[:min_length] && data.length < options[:min_length]
+        return [data, :max_length] if options[:max_length] && data.length > options[:max_length]
         data.each_with_index do |el, i|
           el_filtered, el_error = filter_element(el)
           el_error = ErrorAtom.new(@name, el_error, :index => i) if el_error.is_a?(Symbol)

--- a/spec/array_filter_spec.rb
+++ b/spec/array_filter_spec.rb
@@ -189,4 +189,18 @@ describe "Mutations::ArrayFilter" do
     assert_equal [1,2,4,5], filtered
     assert_equal nil, errors
   end
+
+  it "considers long arrays to be valid" do
+    f = Mutations::ArrayFilter.new(:arr, :min_length => 2)
+    filtered, errors = f.filter([1, 2])
+    assert_equal [1, 2], filtered
+    assert_equal nil, errors
+  end
+
+  it "considers short arrays to be invalid" do
+    f = Mutations::ArrayFilter.new(:arr, :min_length => 2)
+    filtered, errors = f.filter([1])
+    assert_equal [1], filtered
+    assert_equal :min_length, errors
+  end
 end

--- a/spec/array_filter_spec.rb
+++ b/spec/array_filter_spec.rb
@@ -203,4 +203,18 @@ describe "Mutations::ArrayFilter" do
     assert_equal [1], filtered
     assert_equal :min_length, errors
   end
+
+  it "sets a max_length for the array of 20 with one element as valid" do
+    f = Mutations::ArrayFilter.new(:arr, :max_length => 20)
+    filtered, errors = f.filter([1])
+    assert_equal [1], filtered
+    assert_equal nil, errors
+  end
+  
+  it "sets a max_length for the array of 2 with 5 as invalid" do
+    f = Mutations::ArrayFilter.new(:arr, :max_length => 2)
+    filtered, errors = f.filter([1,2,3,4,5])
+    assert_equal [1,2,3,4,5], filtered
+    assert_equal :max_length, errors
+  end
 end


### PR DESCRIPTION
This adds a new option to the `ArrayFilter` `min_length`. Adding this option lets you return errors for required arrays that are smaller than the array `length`. This option is `nil` by default so it's not a breaking change.

```ruby
require do
  # require the items array to contain at least 2 objects
  array :items, min_length: 2
end
```

All specs pass
```text
Finished in 0.054091s, 3882.3464 runs/s, 8929.3968 assertions/s.
210 runs, 483 assertions, 0 failures, 0 errors, 0 skips
```
