### PR TITLE
Retain fullname for command keys on error

### DIFF
--- a/lib/mutations/errors.rb
+++ b/lib/mutations/errors.rb
@@ -47,10 +47,15 @@ module Mutations
     #  :index -- index of error if it's in an array
     def message(key, error_symbol, options = {})
       if options[:index]
-        "#{(key || 'array').to_s.titleize}[#{options[:index]}] #{MESSAGES[error_symbol]}"
+        "#{titleize(key || 'array')}[#{options[:index]}] #{MESSAGES[error_symbol]}"
       else
-        "#{key.to_s.titleize} #{MESSAGES[error_symbol]}"
+        "#{titleize(key)} #{MESSAGES[error_symbol]}"
       end
+    end
+
+    def titleize(key)
+      return "#{key.to_s.titleize} ID" if key.to_s.downcase.end_with?("_id")
+      key.to_s.titleize
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -60,6 +60,11 @@ describe "Mutations - errors" do
     assert_equal "Newsletter Subscription isn't a boolean", atom.message
   end
 
+  it "titleizes keys and keeps Id postfix" do
+    atom = Mutations::ErrorAtom.new(:newsletter_subscription_id, :boolean)
+    assert_equal "Newsletter Subscription ID isn't a boolean", atom.message
+  end
+
   describe "Bunch o errors" do
     before do
       @outcome = GivesErrors.run(:str1 => "", :str2 => "opt9", :int1 => "zero", :hash1 => {:bool1 => "bob"}, :arr1 => ["bob", 1, "sally"])


### PR DESCRIPTION
The mutations gem depend on the `titleize` method in Rails that converts a string to a title like form.

**E.g.:** `my_app_id` to `My App Id`

Though, pre Rails `5.2`, the `titleize` method which depends on the `humanize` will truncate "_id" from the end of strings.

**Example:**

If I have the following command class:

```ruby
class DoStuff < Mutations::Command

  required do
    string :my_app_id
  end

  def execute
  end
end
```

If I run this, and it hard fails, the output will be:

```
Mutations::ValidationException: My App is required
```

This is a very confusing command key description, it should be `My App Id`. This PR is an attempt to handle this, and use the new Rails `titleize` option `keep_id_suffix: true`.

https://github.com/rails/rails/issues/26011
https://github.com/rails/rails/pull/28480