### PR TITLE
Allow filters to be reused across commands

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -20,6 +20,21 @@ module Mutations
       end
       private :create_attr_methods
 
+      def shared_filter_for(filter_name)
+        shared_filters.fetch(filter_name.to_s)
+      rescue KeyError
+        raise SharedParamsNotFound, ":#{filter_name} not found in #{name}"
+      end
+
+      def shared_filters
+        @shared_filters ||= {}
+      end
+      private :shared_filters
+
+      def shared(filter_name, &filter)
+        shared_filters[filter_name.to_s] = filter
+      end
+
       def required(&block)
         create_attr_methods(:required, &block)
       end

--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -10,6 +10,10 @@ module Mutations
       self.options = (self.class.default_options || {}).merge(opts)
     end
 
+    def use(filter_name, from:)
+      instance_eval(&from.shared_filter_for(filter_name))
+    end
+
     # returns -> [sanitized data, error]
     # If an error is returned, then data will be nil
     def filter(data)

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -300,4 +300,39 @@ describe "Command" do
     end
   end
 
+  describe "FamilyCommand" do
+    class PersonCommand < Mutations::Command
+
+      shared :person_attributes do
+        string :name
+        integer :age
+      end
+
+      required do
+        use :person_attributes, from: PersonCommand
+      end
+    end
+
+    class FamilyCommand < Mutations::Command
+
+      required do
+        array :members do
+          hash do
+            use :person_attributes, from: PersonCommand
+          end
+        end
+      end
+
+      def execute
+        members.map(&:symbolize_keys)
+      end
+    end
+
+    it "should use filters from PersonCommand" do
+      input = { members: [{ name: "Intercomrade", age: 6 }] }
+      output = FamilyCommand.run!(members: [{ name: "Intercomrade", age: 6 }])
+      assert_equal(input[:members], output)
+    end
+  end
+
 end


### PR DESCRIPTION
This PR enables filters to be shared between commands. This comes in
handy when multiple commands expect the same input (i.e.: create and
update commands).

The proposed DSL to support this is:

```ruby
class CreateUserCommand < Mutations::Command
  shared :user_filter do
    string :name
    string :email
  end

  required do
    hash :user do
      use :user_filter, from: CreateUserCommand
    edn
  end

  def execute
    # do stuff
  end
end

class UpdateUserCommand < Mutations::Command
  required do
    hash :user do
      integer :id
      use :user_filter, from: CreateUserCommand
    edn
  end

  def execute
    # do stuff
  end
end
```

Two new keywords are added `shared` and `use` to enable filters to be
shared and reused across commands.

Is this something you would consider merging in?