### PR TITLE
Strip unicode format characters in StringFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ sudo: required
 before_install:
   - gem install bundler # the default bundler version on travis is very old and causes 1.9.3 build issues
 rvm:
-  - 1.9.3
-  - jruby-1.7.26
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.1.7.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - rbx-3

--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -28,7 +28,10 @@ module Mutations
       return [data, :string] unless data.is_a?(String)
 
       # At this point, data is a string. Now remove unprintable characters from the string:
-      data = data.gsub(/[^[:print:]\t\r\n]+/, ' ') unless options[:allow_control_characters]
+      unless options[:allow_control_characters]
+        data = data.gsub(/[^[:print:]\t\r\n]+/, ' ')
+        data.gsub!(/\p{Format}/, '') # Ref: http://www.fileformat.info/info/unicode/category/Cf/list.htm
+      end
 
       # Transform it using strip:
       data = data.strip if options[:strip]

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -235,4 +235,17 @@ describe "Mutations::StringFilter" do
     assert_equal nil, errors
   end
 
+  it "removes characters of unicode format class" do
+    sf = Mutations::StringFilter.new(:allow_control_characters => false)
+    filtered, errors = sf.filter("\xEF\xBB\xBFfoo\u200B\u00ADbar")
+    assert_equal "foobar", filtered
+    assert_equal nil, errors
+  end
+
+  it "doesn't remove characters of unicode format class" do
+    sf = Mutations::StringFilter.new(:allow_control_characters => true)
+    filtered, errors = sf.filter("\xEF\xBB\xBFfoo\u200B\u00ADbar")
+    assert_equal "\xEF\xBB\xBFfoo\u200B\u00ADbar", filtered
+    assert_equal nil, errors
+  end
 end


### PR DESCRIPTION
Hi there,

I noticed that the `StringFilter`'s ability to strip control characters misses a few characters that imho should not be present in strings in the vast majority of applications. I'm talking about UTF8 BOM, zero-width characters and such. Everything that belongs to the [Unicode Format class](http://www.fileformat.info/info/unicode/category/Cf/list.htm).

This PR causes the `StringFilter` to strip such characters from strings by default, like it already does with other non-printable characters. 