### PR TITLE
Added empty_is_nil option for StringFilter

### DIFF
--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -4,6 +4,7 @@ module Mutations
       :strip => true,          # true calls data.strip if data is a string
       :strict => false,        # If false, then symbols, numbers, and booleans are converted to a string with to_s.
       :nils => false,          # true allows an explicit nil to be valid. Overrides any other options
+      :empty_is_nil => false,  # if true, treat empty string as if it were nil
       :empty => false,         # false disallows "".  true allows "" and overrides any other validations (b/c they couldn't be true if it's empty)
       :min_length => nil,      # Can be a number like 5, meaning that 5 codepoints are required
       :max_length => nil,      # Can be a number like 10, meaning that at most 10 codepoints are permitted
@@ -14,6 +15,9 @@ module Mutations
     }
 
     def filter(data)
+      if options[:empty_is_nil] && data == ""
+        data = nil
+      end
 
       # Handle nil case
       if data.nil?

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -59,6 +59,19 @@ describe "Mutations::StringFilter" do
     assert_equal nil, errors
   end
 
+  it "considers empty strings to be nil if empty_is_nil option is used" do
+    f = Mutations::StringFilter.new(:empty_is_nil => true)
+    _filtered, errors = f.filter("")
+    assert_equal :nils, errors
+  end
+
+  it "returns empty strings as nil if empty_is_nil option is used" do
+    f = Mutations::StringFilter.new(:empty_is_nil => true, :nils => true)
+    filtered, errors = f.filter("")
+    assert_equal nil, filtered
+    assert_equal nil, errors
+  end
+
   it "considers empty strings to be invalid" do
     sf = Mutations::StringFilter.new(:empty => false)
     filtered, errors = sf.filter("")


### PR DESCRIPTION
**Purpose:**
When using a deserialized object with a parameter that may contain a value but is otherwise assigned as an empty string, we want to avoid a `Mutations::ValidationException (Value can't be blank)` error by explicitly considering empty string values as nils.

**Example:**
```ruby
class Input < Mutations::Command
...
optional do
  string :value, empty_is_nil: true, nils: true
end
```


Local tests passing:
```
$  bundle exec rake
Run options: --seed 8855

# Running tests:

...........................................................................................................................................................................................................................

Finished tests in 0.017328s, 12638.5042 tests/s, 29143.5826 assertions/s.

219 tests, 505 assertions, 0 failures, 0 errors, 0 skips
```