### PR TITLE
Enable dynamic defaults for attributes

### DIFF
--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -21,7 +21,11 @@ module Mutations
     end
 
     def default
-      options[:default]
+      if options[:default].is_a?(Proc)
+        options[:default].call
+      else
+        options[:default]
+      end
     end
 
     # Only relevant for optional params

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -6,6 +6,7 @@ describe 'Mutations - defaults' do
   class DefaultCommand < Mutations::Command
     required do
       string :name, :default => "Bob Jones"
+      string :dynamic_name, :default => -> { "Bob Dynamicpants" }
     end
 
     def execute
@@ -16,13 +17,13 @@ describe 'Mutations - defaults' do
   it "should have a default if no value is passed" do
     outcome = DefaultCommand.run
     assert_equal true, outcome.success?
-    assert_equal({"name" => "Bob Jones"}, outcome.result)
+    assert_equal({"name" => "Bob Jones", "dynamic_name" => "Bob Dynamicpants"}, outcome.result)
   end
 
   it "should have the passed value if a value is passed" do
-    outcome = DefaultCommand.run(:name => "Fred")
+    outcome = DefaultCommand.run(:name => "Fred", :dynamic_name => "Fred")
     assert_equal true, outcome.success?
-    assert_equal({"name" => "Fred"}, outcome.result)
+    assert_equal({"name" => "Fred", "dynamic_name" => "Fred"}, outcome.result)
   end
 
   it "should be an error if nil is passed on a required field with a default" do


### PR DESCRIPTION
Occasionally, we make a mistake where we set a default like this:

```rb
time :starts_at, default: Time.zone.now
```

Unfortunately, `Time.zone.now`'s value will be frozen once the mutation class is loaded. This allows one to write:

```rb
time :starts_at, default: -> { Time.zone.now }
```

And the value will be read dynamically at execution time.

**Note**: this should be a major version bump because it would break compatibility for anyone who genuinely _wanted_ a proc to be the default for their input.