### PR TITLE
dup default values to prevent leaks across calls

### DIFF
--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -21,6 +21,8 @@ module Mutations
     end
 
     def default
+      return options[:default] if options[:default].frozen?
+
       options[:default].dup
     end
 

--- a/lib/mutations/input_filter.rb
+++ b/lib/mutations/input_filter.rb
@@ -21,7 +21,7 @@ module Mutations
     end
 
     def default
-      options[:default]
+      options[:default].dup
     end
 
     # Only relevant for optional params

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -30,4 +30,26 @@ describe 'Mutations - defaults' do
     assert_equal false, outcome.success?
   end
 
+  class DefaultCommandWithValueMutation < Mutations::Command
+    required do
+      string :name
+      array :names, class: String, default: []
+    end
+
+    def execute
+      names << name
+      inputs
+    end
+  end
+
+  it "should not leak values between calls of the command" do
+    outcome = DefaultCommandWithValueMutation.run(name: "Mary")
+    assert_equal true, outcome.success?
+    assert_equal({"name" => "Mary", "names" => ["Mary"]}, outcome.result)
+
+    outcome = DefaultCommandWithValueMutation.run(name: "Joe")
+    assert_equal true, outcome.success?
+    assert_equal({"name" => "Joe", "names" => ["Joe"]}, outcome.result)
+  end
+
 end


### PR DESCRIPTION
Modifies InputFilter to return a dup of the given default value rather than the value itself. This prevents leaks across multiple calls of a command.

Previously, if the validation or execution logic of a command mutated the default value object, that change was persisted to subsequent calls of the command and could lead to unexpected behavior.

By duping the default value in InputFilter, any command logic that mutates the value is prevented from leaking.