### PR TITLE
empty_is_nil and strip options should cooperate.

### DIFF
--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -15,10 +15,6 @@ module Mutations
     }
 
     def filter(data)
-      if options[:empty_is_nil] && data == ""
-        data = nil
-      end
-
       # Handle nil case
       if data.nil?
         return [nil, nil] if options[:nils]
@@ -39,7 +35,9 @@ module Mutations
 
       # Now check if it's blank:
       if data == ""
-        if options[:empty]
+        if options[:empty_is_nil]
+          return [nil, (:nils unless options[:nils])]
+        elsif options[:empty]
           return [data, nil]
         else
           return [data, :empty]

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -93,6 +93,20 @@ describe "Mutations::StringFilter" do
     assert_equal :empty, errors
   end
 
+  it "considers stripped strings that are blank to be nil if empty_is_nil option is used" do
+    sf = Mutations::StringFilter.new(:strip => true, :empty_is_nil => true, :nils => true)
+    filtered, errors = sf.filter("   ")
+    assert_equal nil, filtered
+    assert_equal nil, errors
+  end
+
+  it "considers stripped strings that are blank to be invalid if empty_is_nil option is used" do
+    sf = Mutations::StringFilter.new(:strip => true, :empty_is_nil => true)
+    filtered, errors = sf.filter("   ")
+    assert_equal nil, filtered
+    assert_equal :nils, errors
+  end
+
   it "considers strings that contain only unprintable characters to be invalid" do
     sf = Mutations::StringFilter.new(:empty => false)
     filtered, errors = sf.filter("\u0000\u0000")


### PR DESCRIPTION
If option `strip` is given, a blank string will become empty. But `empty_is_nil` was already checked, so it is not converted to nil.

With this change, when both `empty_is_nil` and `strip` are given, an input like `"     "` is correctly converted to nil.