### PR TITLE
Don't use full key in nested error messages

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -119,7 +119,7 @@ module Mutations
         inner = path.inject(errs) do |cur_errors,part|
           cur_errors[part.to_sym] ||= ErrorHash.new
         end
-        inner[last] = ErrorAtom.new(key, kind, :message => message)
+        inner[last] = ErrorAtom.new(last.to_sym, kind, :message => message)
       end
     end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -223,6 +223,7 @@ describe "Command" do
       assert !outcome.success?
       assert_nil outcome.result
       assert_equal :is_a_bob, outcome.errors[:people].symbolic[:bob]
+      assert_equal "Bob is invalid", outcome.errors[:people].message[:bob]
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/cypriss/mutations/issues/142.

This matches the behaviour when an error is added by a nested filter.