### PR TITLE
Don't remove unknown characters in string filter

### DIFF
--- a/lib/mutations/string_filter.rb
+++ b/lib/mutations/string_filter.rb
@@ -11,7 +11,7 @@ module Mutations
       :matches => nil,         # Can be a regexp
       :in => nil,              # Can be an array like %w(red blue green)
       :discard_empty => false, # If the param is optional, discard_empty: true drops empty fields.
-      :allow_control_characters => false    # false removes unprintable characters from the string
+      :allow_control_characters => false    # false removes control characters from the string
     }
 
     def filter(data)
@@ -27,8 +27,8 @@ module Mutations
       # Now ensure it's a string:
       return [data, :string] unless data.is_a?(String)
 
-      # At this point, data is a string. Now remove unprintable characters from the string:
-      data = data.gsub(/[^[:print:]\t\r\n]+/, ' ') unless options[:allow_control_characters]
+      # At this point, data is a string. Now remove control characters from the string:
+      data = data.gsub(/((?=[[:cntrl:]])[^\t\r\n])+/, ' ') unless options[:allow_control_characters]
 
       # Transform it using strip:
       data = data.strip if options[:strip]

--- a/spec/string_filter_spec.rb
+++ b/spec/string_filter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe "Mutations::StringFilter" do
@@ -107,7 +109,7 @@ describe "Mutations::StringFilter" do
     assert_equal :nils, errors
   end
 
-  it "considers strings that contain only unprintable characters to be invalid" do
+  it "considers strings that contain only control characters to be invalid" do
     sf = Mutations::StringFilter.new(:empty => false)
     filtered, errors = sf.filter("\u0000\u0000")
     assert_equal "", filtered
@@ -241,14 +243,14 @@ describe "Mutations::StringFilter" do
     assert_equal :string, errors
   end
 
-  it "removes unprintable characters" do
+  it "removes control characters" do
     sf = Mutations::StringFilter.new(:allow_control_characters => false)
     filtered, errors = sf.filter("Hello\u0000\u0000World!")
     assert_equal "Hello World!", filtered
     assert_equal nil, errors
   end
 
-  it "doesn't remove unprintable characters" do
+  it "doesn't remove control characters" do
     sf = Mutations::StringFilter.new(:allow_control_characters => true)
     filtered, errors = sf.filter("Hello\u0000\u0000World!")
     assert_equal "Hello\u0000\u0000World!", filtered
@@ -259,6 +261,13 @@ describe "Mutations::StringFilter" do
     sf = Mutations::StringFilter.new(:allow_control_characters => false)
     filtered, errors = sf.filter("Hello,\tWorld !\r\nNew Line")
     assert_equal "Hello,\tWorld !\r\nNew Line", filtered
+    assert_equal nil, errors
+  end
+
+  it "doesn't remove emoji" do
+    sf = Mutations::StringFilter.new(:allow_control_characters => false)
+    filtered, errors = sf.filter("😂🙂🙃🤣🤩🥰🥱")
+    assert_equal "😂🙂🙃🤣🤩🥰🥱", filtered
     assert_equal nil, errors
   end
 


### PR DESCRIPTION
Fixes https://github.com/cypriss/mutations/issues/136.

The `[:print:]` bracket expression only includes known characters, so it only covers Unicode versions supported by the current version of Ruby.

This means that if a client sends a string containing a character that wasn't yet defined when the current version of Ruby was released, it will be incorrectly identified as "unprintable" and removed.

Instead of removing anything not included in `[:print:]`, we can remove everything included in `[:cntrl:]`. This means unknown characters won't be matched, and the behaviour won't depend on the current Ruby version.