### PR TITLE
Module for declaring dependencies between validations

### DIFF
--- a/lib/mutations/dependent_validations.rb
+++ b/lib/mutations/dependent_validations.rb
@@ -1,0 +1,108 @@
+module Mutations
+  module DependentValidations
+
+    # This module allows you to declare dependencies between your validatios and only run them if
+    # all the validations they depend on have already been run and passed.
+    #
+    # For example, suppose you have a user whose email TLD must match their country, but they may
+    # not have provided a location yet. You might define the command like so:
+    #
+    # class UpdateEmail < Mutations::Command
+    #   def validate
+    #     validate_country_code
+    #     validate_email
+    #   end
+    #
+    #   def validate_country_code
+    #     return unless user.country_code.blank?
+    #
+    #     add_error(:country, :not_provided, "You must provide your location first")
+    #   end
+    #
+    #   def validate_email
+    #     return if user.country_code.blank?
+    #     return if email.tld == user.country_code
+    #
+    #     add_error(:email, :mismatching_tld, "Your email's TLD must match your country code")
+    #   end
+    # end
+    #
+    # But this can quickly become unwieldy as validations further depend on each other. Failing to
+    # add the correct guards can result in confusing error messages (in this case, telling the user
+    # their email must match their country code, which they never provided).
+    #
+    # With this module, this becomes:
+    #
+    # class UpdateEmail < Mutations::Command
+    #   include Mutations::DependentValidations
+    #
+    #   def validations
+    #     {
+    #       validate_country_code:[],
+    #       validate_email: %i[validate_country_code],
+    #     }
+    #   end
+    #
+    #   def validate_country_code
+    #     return unless user.country_code.blank?
+    #
+    #     add_error(:country, :not_provided, "You must provide your location first")
+    #   end
+    #
+    #   def validate_email
+    #     return if email.tld == user.country_code
+    #
+    #     add_error(:email, :mismatching_tld, "Your email's TLD must match your country code")
+    #   end
+    # end
+    #
+    # Importantly, note that we no longer invert #validate_country_code's guards in #validate_email,
+    # nor do we provide an implementation of #validate, which is provided by the module.
+
+    CyclicDependencyError = Class.new(StandardError)
+    InvalidValidationsError = Class.new(StandardError)
+    UndefinedValidationsError = Class.new(StandardError)
+    UndeclaredValidationError = Class.new(StandardError)
+
+    def validate
+      raise UndefinedValidationsError, "No validations provided (as .validations class method)" unless self.class.respond_to?(:validations, true)
+
+      validations = self.class.validations
+      raise InvalidValidationsError, "All validations and dependencies must be symbols" unless validations.all? { |k,v| k.class == Symbol && v.all? { |dep| dep.class == Symbol } }
+
+      undeclared_validations = validations.values.flatten.uniq - validations.keys
+      raise UndeclaredValidationError, "Undeclared validations: #{undeclared_validations}, all dependencies must be explicit" if undeclared_validations.any?
+
+      validation_outcomes = {}
+      validations.keys.each do |validation|
+        # This executes validations and their dependencies, depth-first. In the example above, we
+        # would always run the address check first, regardless of the order in which .validations
+        # defines the dependencies.
+        recursively_run_validation(validation, validation_outcomes, Set.new)
+      end
+    end
+
+    def recursively_run_validation(validation, outcomes, seen_validations)
+      # If we already ran this validation, it's a met dependency and we can ignore it.
+      return if outcomes.key?(validation)
+      raise CyclicDependencyError, "Encountered #{validation} twice when evaluating validation dependencies" if seen_validations.member?(validation)
+
+      seen_validations.add(validation)
+      depends_on = self.class.validations[validation]
+      depends_on.each do |dependency|
+        recursively_run_validation(dependency, outcomes, seen_validations)
+      end
+
+      outcomes[validation] = if depends_on.all? { |dependency| outcomes[dependency] == :success }
+        # No errors defined is equivalent to zero errors in this context.
+        error_count = ->() { (defined?(@errors) && !@errors.nil?) ? @errors.size : 0 }
+        initial_error_count = error_count.call
+        send(validation)
+        (initial_error_count == error_count.call) ? :success : :fail
+      else
+        :skipped
+      end
+    end
+
+  end
+end

--- a/spec/dependent_validations_spec.rb
+++ b/spec/dependent_validations_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require '../lib/mutations/dependent_validations'
+
+describe "Mutations::DependentValidations" do
+
+  describe "invalid graphs" do
+    class CyclicCommand
+      include Mutations::DependentValidations
+
+      def self.validations
+        {
+          independent_validation: [],
+          cyclic_validation_1: %i[cyclic_validation_2],
+          cyclic_validation_2: %i[cyclic_validation_1],
+        }
+      end
+
+      def independent_validation; end
+    end
+
+    it "rejects cyclic graphs" do
+      assert_raises(Mutations::DependentValidations::CyclicDependencyError) do
+        CyclicCommand.new.validate
+      end
+    end
+
+    class NoEntryCommand
+      include Mutations::DependentValidations
+
+      def self.validations
+        {
+          dependent_validation: %i[undeclared_validation],
+        }
+      end
+    end
+
+    it "rejects graphs with undeclared validations" do
+      assert_raises(Mutations::DependentValidations::UndeclaredValidationError) do
+        NoEntryCommand.new.validate
+      end
+    end
+
+    class IncorrectlyTypedCommand
+      include Mutations::DependentValidations
+
+      def self.validations
+        {
+          dependent_validation: [->() { true }],
+        }
+      end
+    end
+
+    it "rejects graphs of the wrong type" do
+      assert_raises(Mutations::DependentValidations::InvalidValidationsError) do
+        IncorrectlyTypedCommand.new.validate
+      end
+    end
+
+    class NoValidationCommand
+      include Mutations::DependentValidations
+    end
+
+    it "rejects undefined graphs" do
+      assert_raises(Mutations::DependentValidations::UndefinedValidationsError) do
+        NoValidationCommand.new.validate
+      end
+    end
+  end
+  
+  describe "running validations" do
+    class DependentCommand < Mutations::Command
+      include Mutations::DependentValidations
+
+      attr_reader :called_validations
+
+      def self.validations
+        {
+          no_dependents: [],
+          independent_validation_1: [],
+          independent_validation_2: [],
+          dependent_validation_1: %i[independent_validation_1],
+          dependent_validation_2: %i[independent_validation_2],
+          dependent_validation_3: %i[dependent_validation_1 dependent_validation_2],
+          dependent_validation_4: %i[independent_validation_1 dependent_validation_1],
+        }
+      end
+
+      def initialize(passing_validations)
+        @passing_validations = passing_validations
+        @called_validations = []
+      end
+
+      def no_dependents
+        @called_validations << __callee__
+        add_error(__callee__, :failed, "oh no") unless @passing_validations.include?(__callee__)
+      end
+      alias_method :independent_validation_1, :no_dependents
+      alias_method :independent_validation_2, :no_dependents
+      alias_method :dependent_validation_1, :no_dependents
+      alias_method :dependent_validation_2, :no_dependents
+      alias_method :dependent_validation_3, :no_dependents
+      alias_method :dependent_validation_4, :no_dependents
+
+    end
+
+    it "runs all validations successfully" do
+      all_validations = DependentCommand.validations.keys
+      command = DependentCommand.new(all_validations)
+      command.validate
+
+      assert_equal all_validations.sort, command.called_validations.sort
+    end
+
+    it "skips validations whose dependencies failed" do
+      all_validations = DependentCommand.validations.keys 
+      passing_validations = all_validations - [:independent_validation_2]
+      dependent_validations = [:dependent_validation_2, :dependent_validation_3]
+      command = DependentCommand.new(passing_validations)
+      command.validate
+
+      assert_equal (all_validations - dependent_validations).sort, command.called_validations.sort 
+    end
+  end
+
+end


### PR DESCRIPTION
There's a detailed explanation in the comments in the module itself, but in short:

Including this module allows you to declare which validations should be skipped if other validations already failed, preventing duplication of guard conditions or confusing/redundant error messages if validations are incorrectly guarded.