### PR TITLE
FloatFilter to support empty_is_nil option

### DIFF
--- a/lib/mutations/float_filter.rb
+++ b/lib/mutations/float_filter.rb
@@ -1,9 +1,10 @@
 module Mutations
   class FloatFilter < AdditionalFilter
     @default_options = {
-      :nils => false,       # true allows an explicit nil to be valid. Overrides any other options
-      :min => nil,          # lowest value, inclusive
-      :max => nil           # highest value, inclusive
+      :nils => false,          # true allows an explicit nil to be valid. Overrides any other options,
+      :empty_is_nil => false,  # if true, treat empty string as if it were nil
+      :min => nil,             # lowest value, inclusive
+      :max => nil              # highest value, inclusive
     }
 
     def filter(data)
@@ -15,7 +16,13 @@ module Mutations
       end
       
       # Now check if it's empty:
-      return [data, :empty] if data == ""
+      if data == ""
+        if options[:empty_is_nil]
+          return [nil, (:nils unless options[:nils])]
+        else
+          return [data, :empty]
+        end
+      end
 
       # Ensure it's the correct data type (Float)
       if !data.is_a?(Float)

--- a/spec/float_filter_spec.rb
+++ b/spec/float_filter_spec.rb
@@ -72,6 +72,19 @@ describe "Mutations::FloatFilter" do
     assert_equal :empty, errors
   end
 
+  it "considers empty strings to be nil if empty_is_nil option is used" do
+    f = Mutations::FloatFilter.new(:empty_is_nil => true)
+    _filtered, errors = f.filter("")
+    assert_equal :nils, errors
+  end
+
+  it "returns empty strings as nil if empty_is_nil option is used" do
+    f = Mutations::FloatFilter.new(:empty_is_nil => true, :nils => true)
+    filtered, errors = f.filter("")
+    assert_equal nil, filtered
+    assert_equal nil, errors
+  end
+
   it "considers low numbers invalid" do
     f = Mutations::FloatFilter.new(:min => 10)
     filtered, errors = f.filter(3)


### PR DESCRIPTION
Hi, firstly thanks for the work on Mutations. It is really helpful library for us in both small and medium sized projects for business logic.

I just noticed that FloatFilter did not have empty_is_nil option like in IntegerFilter.

This PR is adding that functionality. 

It's useful as just like in integer values, float values can also be "" and it would be nice to handle it in the mutations rather than filtering and making them nil manually, as right now, they will not pass validations at Mutations and return an error that `Field is blank`.

Would appreciate if this is merged.